### PR TITLE
Add aws-infra Network implementation in Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor/
 **/Pulumi.*.yaml
 **/yarn-error.log
 **/.idea
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 vendor/
 **/Pulumi.*.yaml
 **/yarn-error.log
+**/.idea

--- a/python/pulumi_aws_infra/__init__.py
+++ b/python/pulumi_aws_infra/__init__.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 This package provides primitives for building Networks on AWS in a simple
 and composable way.
 """
-

--- a/python/pulumi_aws_infra/__init__.py
+++ b/python/pulumi_aws_infra/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This package provides primitives for building Networks on AWS in a simple
+and composable way.
+"""
+
+from .network import Network

--- a/python/pulumi_aws_infra/__init__.py
+++ b/python/pulumi_aws_infra/__init__.py
@@ -17,4 +17,3 @@ This package provides primitives for building Networks on AWS in a simple
 and composable way.
 """
 
-from .network import Network

--- a/python/pulumi_aws_infra/network.py
+++ b/python/pulumi_aws_infra/network.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 The network module provides the Network class, which is a Python component that creates
 a VPC-based network that conforms with AWS best practices.
@@ -21,6 +20,7 @@ from pulumi.resource import ComponentResource, ResourceOptions
 from pulumi.errors import RunError
 from pulumi_aws import ec2
 from .util import get_aws_az
+
 
 class Network(ComponentResource):
     """
@@ -259,7 +259,7 @@ class Network(ComponentResource):
             subnets = ec2.get_subnet_ids(vpc_id=vpc.id)
             default_security_group = ec2.get_security_group(
                 name="default", vpc_id=vpc.id)
-            net = Network.from_vpc(
+            net = Network(
                 "default-vpc",
                 vpc_id=vpc.id,
                 subnet_ids=subnets.ids,
@@ -269,6 +269,5 @@ class Network(ComponentResource):
                 opts=resource_options)
 
             Network._default_network = net
-            return net
 
         return Network._default_network

--- a/python/pulumi_aws_infra/network.py
+++ b/python/pulumi_aws_infra/network.py
@@ -27,16 +27,17 @@ class Network(ComponentResource):
     """
     _default_network = None
 
-    def __init__(self,
-                 name,                               # type: str
-                 number_of_availability_zones=None,  # type: int
-                 use_private_subnets=None,           # type: bool
-                 vpc_id=None,                        # type: str
-                 subnet_ids=None,                    # type: List[str]
-                 security_group_ids=None,            # type: List[str]
-                 public_subnet_ids=None,             # type: List[str]
-                 opts=None                           # type: ResourceOptions
-                 ):
+    def __init__(
+            self,
+            name,  # type: str
+            number_of_availability_zones=None,  # type: int
+            use_private_subnets=None,  # type: bool
+            vpc_id=None,  # type: str
+            subnet_ids=None,  # type: List[str]
+            security_group_ids=None,  # type: List[str]
+            public_subnet_ids=None,  # type: List[str]
+            opts=None  # type: ResourceOptions
+    ):
         """
         Constructs a new Network with the requested arguments.
 
@@ -48,14 +49,15 @@ class Network(ComponentResource):
         :param public_subnet_ids The IDs of the subnets that are public, if they exist.
         :param opts General Pulumi resource options.
         """
-        ComponentResource.__init__(self, "aws-infra:network:Network", name, {
-            "number_of_availability_zones": number_of_availability_zones,
-            "use_private_subnets": use_private_subnets,
-            "vpc_id": vpc_id,
-            "subnet_ids": subnet_ids,
-            "security_group_ids": security_group_ids,
-            "public_subnet_ids": public_subnet_ids,
-        }, opts)
+        ComponentResource.__init__(
+            self, "aws-infra:network:Network", name, {
+                "number_of_availability_zones": number_of_availability_zones,
+                "use_private_subnets": use_private_subnets,
+                "vpc_id": vpc_id,
+                "subnet_ids": subnet_ids,
+                "security_group_ids": security_group_ids,
+                "public_subnet_ids": public_subnet_ids,
+            }, opts)
 
         # Initialize all of our instance variables at the top, so that an IDE can figure
         # out what shape this class is supposed to have.
@@ -72,15 +74,14 @@ class Network(ComponentResource):
 
         self._register_outputs()
 
-
     def _register_outputs(self):
         self.register_outputs({
-                "vpc_id": self.vpc_id,
-                "subnet_ids": self.subnet_ids,
-                "use_private_subnets": self.use_private_subnets,
-                "security_group_ids": self.security_group_ids,
-                "public_subnet_ids": self.public_subnet_ids
-            })
+            "vpc_id": self.vpc_id,
+            "subnet_ids": self.subnet_ids,
+            "use_private_subnets": self.use_private_subnets,
+            "security_group_ids": self.security_group_ids,
+            "public_subnet_ids": self.public_subnet_ids
+        })
 
     def _create_from_vpc(self):
         if self.subnet_ids is None:
@@ -95,49 +96,52 @@ class Network(ComponentResource):
     def _create_from_arguments(self, name, number_of_availability_zones):
         number_of_availability_zones = number_of_availability_zones or 2
         if number_of_availability_zones < 1 or number_of_availability_zones > 4:
-            raise RunError("Unsupported number of available zones for Network: " + str(number_of_availability_zones))
+            raise RunError(
+                "Unsupported number of available zones for Network: " +
+                str(number_of_availability_zones))
 
         self.use_private_subnets = self.use_private_subnets or False
-        vpc = ec2.Vpc(name,
-                      cidr_block="10.10.0.0/16",
-                      enable_dns_hostnames=True,
-                      enable_dns_support=True,
-                      tags={
-                          "Name": name,
-                      },
-                      __opts__=ResourceOptions(parent=self))
+        vpc = ec2.Vpc(
+            name,
+            cidr_block="10.10.0.0/16",
+            enable_dns_hostnames=True,
+            enable_dns_support=True,
+            tags={
+                "Name": name,
+            },
+            __opts__=ResourceOptions(parent=self))
 
         self.vpc_id = vpc.id
         self.security_group_ids = [vpc.default_security_group_id]
 
-        internet_gateway = ec2.InternetGateway(name,
-                                               vpc_id=vpc.id,
-                                               tags={
-                                                   "Name": name,
-                                               },
-                                               __opts__=ResourceOptions(parent=self))
+        internet_gateway = ec2.InternetGateway(
+            name,
+            vpc_id=vpc.id,
+            tags={
+                "Name": name,
+            },
+            __opts__=ResourceOptions(parent=self))
 
-        public_route_table = ec2.RouteTable(name,
-                                            vpc_id=vpc.id,
-                                            routes=[
-                                                {
-                                                    "cidrBlock": "0.0.0.0/0",
-                                                    "gatewayId": internet_gateway.id
-                                                }
-                                            ],
-                                            tags={
-                                                "Name": name
-                                            },
-                                            __opts__=ResourceOptions(parent=self))
+        public_route_table = ec2.RouteTable(
+            name,
+            vpc_id=vpc.id,
+            routes=[{
+                "cidrBlock": "0.0.0.0/0",
+                "gatewayId": internet_gateway.id
+            }],
+            tags={"Name": name},
+            __opts__=ResourceOptions(parent=self))
 
         self.subnet_ids = []
         self.public_subnet_ids = []
         for i in range(number_of_availability_zones):
-            route_table, subnet = self._create_subnet(name, public_route_table, i)
-            route_table_association = ec2.RouteTableAssociation("%s-%d" % (name, i),
-                                                                subnet_id=subnet.id,
-                                                                route_table_id=route_table.id,
-                                                                __opts__=ResourceOptions(parent=self))
+            route_table, subnet = self._create_subnet(name, public_route_table,
+                                                      i)
+            route_table_association = ec2.RouteTableAssociation(
+                "%s-%d" % (name, i),
+                subnet_id=subnet.id,
+                route_table_id=route_table.id,
+                __opts__=ResourceOptions(parent=self))
 
             self.subnet_ids.append(subnet.id)
 
@@ -145,39 +149,40 @@ class Network(ComponentResource):
         # type: (str, ec2.RouteTable, int) -> (ec2.RouteTable, ec2.Subnet)
         subnet_name = "%s-%d" % (network_name, az_id)
         # Create the subnet for this AZ - either public or private
-        subnet = ec2.Subnet(subnet_name,
-                            vpc_id=self.vpc_id,
-                            availability_zone=get_aws_az(az_id),
-                            cidr_block="10.10.%d.0/24" % az_id,
-                            map_public_ip_on_launch=not self.use_private_subnets,
-                            # Only assign public IP if we are exposing public subnets
-                            tags={
-                                "Name": subnet_name,
-                            },
-                            __opts__=ResourceOptions(parent=self))
+        subnet = ec2.Subnet(
+            subnet_name,
+            vpc_id=self.vpc_id,
+            availability_zone=get_aws_az(az_id),
+            cidr_block="10.10.%d.0/24" % az_id,
+            map_public_ip_on_launch=not self.use_private_subnets,
+            # Only assign public IP if we are exposing public subnets
+            tags={
+                "Name": subnet_name,
+            },
+            __opts__=ResourceOptions(parent=self))
 
         # We will use a different route table for this subnet depending on
         # whether we are in a public or private subnet
         if self.use_private_subnets:
             # We need a public subnet for the NAT Gateway
             nat_name = "%s-nat-%d" % (network_name, az_id)
-            nat_gateway_public_subnet = ec2.Subnet(nat_name,
-                                                   vpc_id=self.vpc_id,
-                                                   availability_zone=get_aws_az(az_id),
-                                                   # Use top half of the subnet space
-                                                   cidr_block="10.10.%d.0/24" % (az_id + 64),
-                                                   # Always assign a public IP in NAT subnet
-                                                   map_public_ip_on_launch=True,
-                                                   tags={
-                                                       "Name": nat_name
-                                                   },
-                                                   __opts__=ResourceOptions(parent=self))
+            nat_gateway_public_subnet = ec2.Subnet(
+                nat_name,
+                vpc_id=self.vpc_id,
+                availability_zone=get_aws_az(az_id),
+                # Use top half of the subnet space
+                cidr_block="10.10.%d.0/24" % (az_id + 64),
+                # Always assign a public IP in NAT subnet
+                map_public_ip_on_launch=True,
+                tags={"Name": nat_name},
+                __opts__=ResourceOptions(parent=self))
 
             # And we need to route traffic from that public subnet to the Internet Gateway
-            nat_gateway_routes = ec2.RouteTableAssociation(nat_name,
-                                                           subnet_id=nat_gateway_public_subnet.id,
-                                                           route_table_id=public_route_table.id,
-                                                           __opts__=ResourceOptions(parent=self))
+            nat_gateway_routes = ec2.RouteTableAssociation(
+                nat_name,
+                subnet_id=nat_gateway_public_subnet.id,
+                route_table_id=public_route_table.id,
+                __opts__=ResourceOptions(parent=self))
 
             self.public_subnet_ids.append(nat_gateway_public_subnet.id)
 
@@ -185,26 +190,23 @@ class Network(ComponentResource):
             eip = ec2.Eip(nat_name, __opts__=ResourceOptions(parent=self))
 
             # And we need a NAT Gateway to be able to access the Internet
-            nat_gateway = ec2.NatGateway(nat_name,
-                                         subnet_id=nat_gateway_public_subnet.id,
-                                         allocation_id=eip.id,
-                                         tags={
-                                             "Name": nat_name
-                                         },
-                                         __opts__=ResourceOptions(parent=self, depends_on=[nat_gateway_routes]))
+            nat_gateway = ec2.NatGateway(
+                nat_name,
+                subnet_id=nat_gateway_public_subnet.id,
+                allocation_id=eip.id,
+                tags={"Name": nat_name},
+                __opts__=ResourceOptions(
+                    parent=self, depends_on=[nat_gateway_routes]))
 
-            nat_route_table = ec2.RouteTable(nat_name,
-                                             vpc_id=self.vpc_id,
-                                             routes=[
-                                                 {
-                                                     "cidrBlock": "0.0.0.0/0",
-                                                     "natGatewayId": nat_gateway.id
-                                                 }
-                                             ],
-                                             tags={
-                                                 "Name": network_name
-                                             },
-                                             __opts__=ResourceOptions(parent=self))
+            nat_route_table = ec2.RouteTable(
+                nat_name,
+                vpc_id=self.vpc_id,
+                routes=[{
+                    "cidrBlock": "0.0.0.0/0",
+                    "natGatewayId": nat_gateway.id
+                }],
+                tags={"Name": network_name},
+                __opts__=ResourceOptions(parent=self))
 
             # Route through the NAT gateway for the private subnet
             return nat_route_table, subnet
@@ -223,14 +225,16 @@ class Network(ComponentResource):
         if Network._default_network is None:
             vpc = ec2.get_vpc(default=True)
             subnets = ec2.get_subnet_ids(vpc_id=vpc.id)
-            default_security_group = ec2.get_security_group(name="default", vpc_id=vpc.id)
-            net = Network.from_vpc("default-vpc",
-                                   vpc_id=vpc.id,
-                                   subnet_ids=subnets.ids,
-                                   use_private_subnets=False,
-                                   security_group_ids=[default_security_group.id],
-                                   public_subnet_ids=subnets.ids,
-                                   opts=resource_options)
+            default_security_group = ec2.get_security_group(
+                name="default", vpc_id=vpc.id)
+            net = Network.from_vpc(
+                "default-vpc",
+                vpc_id=vpc.id,
+                subnet_ids=subnets.ids,
+                use_private_subnets=False,
+                security_group_ids=[default_security_group.id],
+                public_subnet_ids=subnets.ids,
+                opts=resource_options)
 
             Network._default_network = net
             return net

--- a/python/pulumi_aws_infra/network.py
+++ b/python/pulumi_aws_infra/network.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List
 from pulumi.resource import ComponentResource, ResourceOptions
 from pulumi.errors import RunError
 from pulumi_aws import ec2
-from typing import List
 from .util import get_aws_az
 
 

--- a/python/pulumi_aws_infra/network.py
+++ b/python/pulumi_aws_infra/network.py
@@ -1,0 +1,261 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pulumi.resource import ComponentResource, ResourceOptions
+from pulumi.errors import RunError
+from pulumi_aws import ec2
+from typing import List
+from .util import get_aws_az
+
+
+class Network(ComponentResource):
+    """
+    Network is a component resource representing a network configuration in AWS.
+    Networks can consist of public and private subnets across a number of availability
+    zones.
+    """
+    default_network = None
+
+    def __init__(self,
+                 name,                               # type: str
+                 number_of_availability_zones=None,  # type: int
+                 use_private_subnets=None,           # type: bool
+                 vpc_id=None,                        # type: str
+                 subnet_ids=None,                    # type: List[str]
+                 security_group_ids=None,            # type: List[str]
+                 public_subnet_ids=None,             # type: List[str]
+                 opts=None                           # type: ResourceOptions
+                 ):
+        """
+        Constructs a new Network with the requested arguments.
+
+        :param name The name of this network. Used to name all child resources.
+        :param number_of_availability_zones The number of AZs to create subnets in.
+        :param vpc_id The ID of the VPC that this network should be attached to, if one exists.
+        :param subnet_ids The subnet IDs that make up this network, if they exist.
+        :param security_group_ids The security group IDs attached to this network, if they exist.
+        :param public_subnet_ids The IDs of the subnets that are public, if they exist.
+        :param opts General Pulumi resource options.
+        """
+        ComponentResource.__init__(self, "aws-infra:network:Network", name, {
+            "number_of_availability_zones": number_of_availability_zones,
+            "use_private_subnets": use_private_subnets,
+            "vpc_id": vpc_id,
+            "subnet_ids": subnet_ids,
+            "security_group_ids": security_group_ids,
+            "public_subnet_ids": public_subnet_ids,
+        }, opts)
+
+        # Initialize all of our instance variables at the top, so that an IDE can figure
+        # out what shape this class is supposed to have.
+        self.vpc_id = vpc_id
+        self.subnet_ids = subnet_ids
+        self.use_private_subnets = use_private_subnets
+        self.security_group_ids = security_group_ids
+        self.public_subnet_ids = public_subnet_ids
+
+        if vpc_id is not None:
+            self.register_outputs({
+                "vpc_id": self.vpc_id,
+                "subnet_ids": self.subnet_ids,
+                "use_private_subnets": self.use_private_subnets,
+                "security_group_ids": self.security_group_ids,
+                "public_subnet_ids": self.public_subnet_ids
+            })
+            return
+
+        number_of_availability_zones = number_of_availability_zones or 2
+        if number_of_availability_zones < 1 or number_of_availability_zones > 4:
+            raise RunError("Unsupported number of available zones for Network: " + str(number_of_availability_zones))
+
+        self.use_private_subnets = use_private_subnets or False
+        vpc = ec2.Vpc(name,
+                      cidr_block="10.10.0.0/16",
+                      enable_dns_hostnames=True,
+                      enable_dns_support=True,
+                      tags={
+                          "Name": name,
+                      },
+                      __opts__=ResourceOptions(parent=self))
+
+        self.vpc_id = vpc.id
+        self.security_group_ids = [vpc.default_security_group_id]
+
+        internet_gateway = ec2.InternetGateway(name,
+                                               vpc_id=vpc.id,
+                                               tags={
+                                                   "Name": name,
+                                               },
+                                               __opts__=ResourceOptions(parent=self))
+
+        public_route_table = ec2.RouteTable(name,
+                                            vpc_id=vpc.id,
+                                            routes=[
+                                                {
+                                                    "cidrBlock": "0.0.0.0/0",
+                                                    "gatewayId": internet_gateway.id
+                                                }
+                                            ],
+                                            tags={
+                                                "Name": name
+                                            },
+                                            __opts__=ResourceOptions(parent=self))
+
+        self.subnet_ids = []
+        self.public_subnet_ids = []
+        for i in range(number_of_availability_zones):
+            subnet_name = "%s-%s" % (name, i)
+
+            # Create the subnet for this AZ - either - either public or private
+            subnet = ec2.Subnet(subnet_name,
+                                vpc_id=vpc.id,
+                                availability_zone=get_aws_az(i),
+                                cidr_block="10.10.%s.0/24" % i,
+                                map_public_ip_on_launch=not self.use_private_subnets,
+                                # Only assign public IP if we are exposing public subnets
+                                tags={
+                                    "Name": subnet_name,
+                                },
+                                __opts__=ResourceOptions(parent=self))
+
+            # We will use a different route table for this subnet depending on
+            # whether we are in a public or private subnet
+            if self.use_private_subnets:
+                # We need a public subnet for the NAT Gateway
+                nat_name = "%s-nat-%s" % (name, i)
+                nat_gateway_public_subnet = ec2.Subnet(nat_name,
+                                                       vpc_id=vpc.id,
+                                                       availability_zone=get_aws_az(i),
+                                                       cidr_block="10.10.%s.0/24" % (i + 64),
+                                                       # Use top half of the subnet space
+                                                       map_public_ip_on_launch=True,
+                                                       # Always assign a public IP in NAT subnet
+                                                       tags={
+                                                           "Name": nat_name
+                                                       },
+                                                       __opts__=ResourceOptions(parent=self))
+
+                # And we need to route traffic from that public subnet to the Internet Gateway
+                nat_gateway_routes = ec2.RouteTableAssociation(nat_name,
+                                                               subnet_id=nat_gateway_public_subnet.id,
+                                                               route_table_id=public_route_table.id,
+                                                               __opts__=ResourceOptions(parent=self))
+
+                self.public_subnet_ids.append(nat_gateway_public_subnet.id)
+
+                # We need an Elastic IP for the NAT Gateway
+                eip = ec2.Eip(nat_name, __opts__=ResourceOptions(parent=self))
+
+                # And we need a NAT Gateway to be able to access the Internet
+                nat_gateway = ec2.NatGateway(nat_name,
+                                             subnet_id=nat_gateway_public_subnet.id,
+                                             allocation_id=eip.id,
+                                             tags={
+                                                 "Name": nat_name
+                                             },
+                                             __opts__=ResourceOptions(parent=self, depends_on=[nat_gateway_routes]))
+
+                nat_route_table = ec2.RouteTable(nat_name,
+                                                 vpc_id=vpc.id,
+                                                 routes=[
+                                                     {
+                                                         "cidrBlock": "0.0.0.0/0",
+                                                         "natGatewayId": nat_gateway.id
+                                                     }
+                                                 ],
+                                                 tags={
+                                                     "Name": name
+                                                 },
+                                                 __opts__=ResourceOptions(parent=self))
+
+                # Route through the NAT gateway for the private subnet
+                subnet_route_table = nat_route_table
+            else:  # not self.private_subnets
+                # Route directly to the Internet Gateway for the public subnet
+                subnet_route_table = public_route_table
+
+                # The subnet is public, so register it as our public subnet
+                self.public_subnet_ids.append(subnet.id)
+
+            route_table_association = ec2.RouteTableAssociation("%s-%s" % (name, i),
+                                                                subnet_id=subnet.id,
+                                                                route_table_id=subnet_route_table.id,
+                                                                __opts__=ResourceOptions(parent=self))
+
+            self.subnet_ids.append(subnet.id)
+        self.register_outputs({
+            "vpc_id": self.vpc_id,
+            "subnet_ids": self.subnet_ids,
+            "use_private_subnets": self.use_private_subnets,
+            "security_group_ids": self.security_group_ids,
+            "public_subnet_ids": self.public_subnet_ids
+        })
+
+    @staticmethod
+    def get_default(resource_options=None):
+        # type: (ResourceOptions) -> Network
+        """
+        Gets the default VPC for the AWS account as a Network.  This first time this is called,
+        the default network will be lazily created, using whatever options are provided in opts.
+        All subsequent calls will return that same network even if different opts are provided.
+        """
+        if Network.default_network is None:
+            vpc = ec2.get_vpc(default=True)
+            subnets = ec2.get_subnet_ids(vpc_id=vpc.id)
+            default_security_group = ec2.get_security_group(name="default", vpc_id=vpc.id)
+            net = Network.from_vpc("default-vpc",
+                                   vpc_id=vpc.id,
+                                   subnet_ids=subnets.ids,
+                                   use_private_subnets=False,
+                                   security_group_ids=[default_security_group.id],
+                                   public_subnet_ids=subnets.ids,
+                                   opts=resource_options)
+
+            Network.default_network = net
+            return net
+
+        return Network.default_network
+
+    @staticmethod
+    def from_vpc(name,
+                 vpc_id=None,               # type: str
+                 subnet_ids=None,           # type: List[str]
+                 use_private_subnets=None,  # type: bool
+                 security_group_ids=None,   # type: List[str]
+                 public_subnet_ids=None,    # type: List[str]
+                 opts=None                  # type: ResourceOptions
+                 ):
+        # type: (...) -> Network
+        """
+        Constructs a Network from a VPC that already exists.
+        """
+        if vpc_id is None:
+            raise TypeError("vpc_id argument must be provided")
+
+        if subnet_ids is None:
+            raise TypeError("subnet_ids argument must be provided")
+
+        if security_group_ids is None:
+            raise TypeError("security_group_ids must be provided")
+
+        if public_subnet_ids is None:
+            raise TypeError("public_subnet_ids argument must be provided")
+
+        return Network(name,
+                       vpc_id=vpc_id,
+                       subnet_ids=subnet_ids,
+                       use_private_subnets=use_private_subnets,
+                       security_group_ids=security_group_ids,
+                       public_subnet_ids=public_subnet_ids,
+                       opts=opts)

--- a/python/pulumi_aws_infra/network.py
+++ b/python/pulumi_aws_infra/network.py
@@ -114,7 +114,7 @@ class Network(ComponentResource):
         :return: None
         """
         number_of_availability_zones = number_of_availability_zones or 2
-        if number_of_availability_zones < 1 or number_of_availability_zones > 4:
+        if number_of_availability_zones < 1 or number_of_availability_zones >= 4:
             raise RunError(
                 "Unsupported number of available zones for Network: " +
                 str(number_of_availability_zones))

--- a/python/pulumi_aws_infra/util.py
+++ b/python/pulumi_aws_infra/util.py
@@ -14,6 +14,7 @@
 
 import pulumi_aws
 
+
 def get_aws_az(index):
     # type: (int) -> str
     zones = pulumi_aws.get_availability_zones()

--- a/python/pulumi_aws_infra/util.py
+++ b/python/pulumi_aws_infra/util.py
@@ -1,0 +1,20 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pulumi_aws
+
+def get_aws_az(index):
+    # type: (int) -> str
+    zones = pulumi_aws.get_availability_zones()
+    return zones.names[index]

--- a/python/setup.py
+++ b/python/setup.py
@@ -25,6 +25,6 @@ setup(name='pulumi_aws_infra',
       packages=find_packages(),
       install_requires=[
           'typing>=3.6',
-          'pulumi>=0.13.0,<0.15.0',
-          'pulumi_aws>=0.13'
+          'pulumi>=0.14.0,<0.15.0',
+          'pulumi_aws>=0.14'
       ])

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,30 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from setuptools import setup, find_packages
+
+setup(name='pulumi_aws_infra',
+      version='${VERSION}',
+      description='Pulumi Amazon Web Services (AWS) infrastructure components.',
+      keywords='pulumi aws aws-infra',
+      url='https://pulumi.io/pulumi-aws-infra',
+      project_urls={
+          'Repository': 'https://github.com/pulumi/pulumi-aws-infra'
+      },
+      packages=find_packages(),
+      install_requires=[
+          'typing>=3.6',
+          'pulumi>0.12.2,<0.13.0',
+          'pulumi_aws>=0.13'
+      ])

--- a/python/setup.py
+++ b/python/setup.py
@@ -23,5 +23,5 @@ setup(
     project_urls={'Repository': 'https://github.com/pulumi/pulumi-aws-infra'},
     packages=find_packages(),
     install_requires=[
-        'typing>=3.6', 'pulumi>=0.14.0,<0.15.0', 'pulumi_aws>=0.14'
+        'pulumi>=0.14.0,<0.15.0', 'pulumi_aws>=0.14'
     ])

--- a/python/setup.py
+++ b/python/setup.py
@@ -14,17 +14,14 @@
 
 from setuptools import setup, find_packages
 
-setup(name='pulumi_aws_infra',
-      version='${VERSION}',
-      description='Pulumi Amazon Web Services (AWS) infrastructure components.',
-      keywords='pulumi aws aws-infra',
-      url='https://github.com/pulumi/pulumi-aws-infra',
-      project_urls={
-          'Repository': 'https://github.com/pulumi/pulumi-aws-infra'
-      },
-      packages=find_packages(),
-      install_requires=[
-          'typing>=3.6',
-          'pulumi>=0.14.0,<0.15.0',
-          'pulumi_aws>=0.14'
-      ])
+setup(
+    name='pulumi_aws_infra',
+    version='${VERSION}',
+    description='Pulumi Amazon Web Services (AWS) infrastructure components.',
+    keywords='pulumi aws aws-infra',
+    url='https://github.com/pulumi/pulumi-aws-infra',
+    project_urls={'Repository': 'https://github.com/pulumi/pulumi-aws-infra'},
+    packages=find_packages(),
+    install_requires=[
+        'typing>=3.6', 'pulumi>=0.14.0,<0.15.0', 'pulumi_aws>=0.14'
+    ])

--- a/python/setup.py
+++ b/python/setup.py
@@ -18,13 +18,13 @@ setup(name='pulumi_aws_infra',
       version='${VERSION}',
       description='Pulumi Amazon Web Services (AWS) infrastructure components.',
       keywords='pulumi aws aws-infra',
-      url='https://pulumi.io/pulumi-aws-infra',
+      url='https://github.com/pulumi/pulumi-aws-infra',
       project_urls={
           'Repository': 'https://github.com/pulumi/pulumi-aws-infra'
       },
       packages=find_packages(),
       install_requires=[
           'typing>=3.6',
-          'pulumi>0.12.2,<0.13.0',
+          'pulumi>=0.13.0,<0.15.0',
           'pulumi_aws>=0.13'
       ])


### PR DESCRIPTION
This code came out of last Thursday's hackathon and serves as an example and test that we can write non-trivial components in Python.

This code is translated pretty much verbatim from the TypeScript implementation in this repo. All of this code is known to work with tip-of-master builds of `pulumi` and `pulumi-aws`, but we'll need to do another pass once the `v0.14` SDK drops.

Follow-up PRs will do the plumbing required to publish this package to PyPI.