### PR TITLE
Update licenses in package.json files.

### DIFF
--- a/nodejs/aws-infra/examples/cluster/package.json
+++ b/nodejs/aws-infra/examples/cluster/package.json
@@ -1,6 +1,7 @@
 {
     "name": "cluster",
     "version": "0.1",
+    "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {

--- a/nodejs/aws-infra/package.json
+++ b/nodejs/aws-infra/package.json
@@ -2,7 +2,7 @@
     "name": "@pulumi/aws-infra",
     "version": "${VERSION}",
     "description": "Pulumi Amazon Web Services (AWS) infrastructure components.",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "keywords": [
         "pulumi",
         "aws",


### PR DESCRIPTION
This gets rid of all the:

```
warning package.json: License should be a valid SPDX license expression
warning @pulumi/aws-infra@${VERSION}: License should be a valid SPDX license expression
```

messages that show up while building.