### PR TITLE
Make test package versions valid semvers

### DIFF
--- a/nodejs/aws-infra/examples/cluster/package.json
+++ b/nodejs/aws-infra/examples/cluster/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cluster",
-    "version": "0.1",
+    "version": "0.0.1",
     "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",


### PR DESCRIPTION
NPM and some other packages (including read-package-json that
@pulumi/pulumi) uses require the version field to be a valid
semver. So ensure ours are.