### PR TITLE
Update aws package to latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
     - sudo apt-get -y install docker-ce=17.09.0~ce-0~ubuntu
     - docker version
     # Install Pulumi
-    - curl -L https://get.pulumi.com/ | bash -s -- --version 0.14.0
+    - curl -L https://get.pulumi.com/ | bash -s -- --version 0.14.4-dev-1533786685-g80569fb5
     - export PATH=$HOME/.pulumi/bin:$PATH
 before_script:
     - ${PULUMI_SCRIPTS}/ci/ensure-dependencies

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -23,40 +23,15 @@
   version = "v1.0.5"
 
 [[projects]]
-  name = "github.com/agext/levenshtein"
-  packages = ["."]
-  revision = "5f10fee965225ac1eecdc234c09daf5cd9e7f7b6"
-  version = "v1.2.1"
-
-[[projects]]
   name = "github.com/apache/thrift"
   packages = ["lib/go/thrift"]
   revision = "b2a4d4ae21c789b689dd162deb819665567f481c"
   version = "0.10.0"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/apparentlymart/go-cidr"
-  packages = ["cidr"]
-  revision = "2bd8b58cf4275aeb086ade613de226773e29e853"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/apparentlymart/go-textseg"
-  packages = ["textseg"]
-  revision = "b836f5c4d331d1945a2fead7188db25432d73b69"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/armon/go-radix"
-  packages = ["."]
-  revision = "1fca145dffbcaa8fe914309b1ec0cfc67500fe61"
-
-[[projects]]
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
-    "aws/arn",
     "aws/awserr",
     "aws/awsutil",
     "aws/client",
@@ -74,91 +49,19 @@
     "aws/signer/v4",
     "internal/shareddefaults",
     "private/protocol",
-    "private/protocol/ec2query",
     "private/protocol/json/jsonutil",
     "private/protocol/jsonrpc",
     "private/protocol/query",
     "private/protocol/query/queryutil",
     "private/protocol/rest",
-    "private/protocol/restjson",
     "private/protocol/restxml",
     "private/protocol/xml/xmlutil",
-    "private/signer/v2",
-    "service/acm",
-    "service/apigateway",
-    "service/applicationautoscaling",
-    "service/athena",
-    "service/autoscaling",
-    "service/batch",
-    "service/cloudformation",
-    "service/cloudfront",
-    "service/cloudtrail",
-    "service/cloudwatch",
-    "service/cloudwatchevents",
     "service/cloudwatchlogs",
-    "service/codebuild",
-    "service/codecommit",
-    "service/codedeploy",
-    "service/codepipeline",
-    "service/cognitoidentity",
-    "service/cognitoidentityprovider",
-    "service/configservice",
-    "service/databasemigrationservice",
-    "service/devicefarm",
-    "service/directconnect",
-    "service/directoryservice",
-    "service/dynamodb",
-    "service/ec2",
-    "service/ecr",
-    "service/ecs",
-    "service/efs",
-    "service/elasticache",
-    "service/elasticbeanstalk",
-    "service/elasticsearchservice",
-    "service/elastictranscoder",
-    "service/elb",
-    "service/elbv2",
-    "service/emr",
-    "service/firehose",
-    "service/glacier",
-    "service/iam",
-    "service/inspector",
-    "service/iot",
-    "service/kinesis",
-    "service/kms",
-    "service/lambda",
-    "service/lightsail",
-    "service/mq",
-    "service/opsworks",
-    "service/rds",
-    "service/redshift",
-    "service/route53",
     "service/s3",
-    "service/servicecatalog",
-    "service/ses",
-    "service/sfn",
-    "service/simpledb",
-    "service/sns",
-    "service/sqs",
-    "service/ssm",
-    "service/sts",
-    "service/waf",
-    "service/wafregional"
+    "service/sts"
   ]
   revision = "107df09c5f137b9dfe53b7a4c25dd4d79f81390f"
   version = "v1.12.40"
-
-[[projects]]
-  name = "github.com/beevik/etree"
-  packages = ["."]
-  revision = "15a30b44cfd6c5a16a7ddfe271bf146aaf2d3195"
-  version = "v1.0.0"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/bgentry/go-netrc"
-  packages = ["netrc"]
-  revision = "9fd32a8b3d3d3f9d43c341bfe098430e07609480"
 
 [[projects]]
   name = "github.com/bgentry/speakeasy"
@@ -225,7 +128,6 @@
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
-  branch = "master"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -237,13 +139,8 @@
     "ptypes/struct",
     "ptypes/timestamp"
   ]
-  revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/golang/snappy"
-  packages = ["."]
-  revision = "553a641470496b2327abcac10b36396bd98e45c9"
+  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
@@ -259,126 +156,9 @@
 
 [[projects]]
   branch = "master"
-  name = "github.com/hashicorp/go-cleanhttp"
-  packages = ["."]
-  revision = "d5fe4b57a186c716b0e00b8c301cbd9b4182694d"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/hashicorp/go-getter"
-  packages = [
-    ".",
-    "helper/url"
-  ]
-  revision = "285374cdfad63de2c43d7562f49ced6dde5a7ba0"
-
-[[projects]]
-  branch = "master"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
   revision = "b7773ae218740a7be65057fc60b366a49b538a44"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/hashicorp/go-uuid"
-  packages = ["."]
-  revision = "64130c7a86d732268a38cb04cfbaf0cc987fda98"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/hashicorp/go-version"
-  packages = ["."]
-  revision = "4fe82ae3040f80a03d04d2cccb5606a626b8e1ee"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/hashicorp/hcl"
-  packages = [
-    ".",
-    "hcl/ast",
-    "hcl/parser",
-    "hcl/scanner",
-    "hcl/strconv",
-    "hcl/token",
-    "json/parser",
-    "json/scanner",
-    "json/token"
-  ]
-  revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/hashicorp/hcl2"
-  packages = [
-    "gohcl",
-    "hcl",
-    "hcl/hclsyntax",
-    "hcl/json",
-    "hcldec",
-    "hclparse"
-  ]
-  revision = "5ca9713bf06addcefc0a4e16f779e43a2c88570c"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/hashicorp/hil"
-  packages = [
-    ".",
-    "ast",
-    "parser",
-    "scanner"
-  ]
-  revision = "fa9f258a92500514cc8e9c67020487709df92432"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/hashicorp/logutils"
-  packages = ["."]
-  revision = "0dc08b1671f34c4250ce212759ebd880f743d883"
-
-[[projects]]
-  name = "github.com/hashicorp/terraform"
-  packages = [
-    "config",
-    "config/configschema",
-    "config/hcl2shim",
-    "config/module",
-    "dag",
-    "flatmap",
-    "helper/config",
-    "helper/encryption",
-    "helper/hashcode",
-    "helper/hilmapstructure",
-    "helper/logging",
-    "helper/mutexkv",
-    "helper/resource",
-    "helper/schema",
-    "helper/structure",
-    "helper/validation",
-    "moduledeps",
-    "plugin/discovery",
-    "registry",
-    "registry/regsrc",
-    "registry/response",
-    "svchost",
-    "svchost/auth",
-    "svchost/disco",
-    "terraform",
-    "tfdiags",
-    "version"
-  ]
-  revision = "3802b14260603f90c7a1faf55994dcc8933e2069"
-  version = "v0.11.3"
-
-[[projects]]
-  name = "github.com/hashicorp/vault"
-  packages = [
-    "helper/compressutil",
-    "helper/jsonutil",
-    "helper/pgpkeys"
-  ]
-  revision = "5acd6a21d5a69ab49d0f7c0bf540123a9b2c696d"
-  version = "v0.9.3"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
@@ -393,12 +173,6 @@
   revision = "d14ea06fba99483203c19d92cfcd13ebe73135f4"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/jen20/awspolicyequivalence"
-  packages = ["."]
-  revision = "3d48364a137a7847c1191b83740052dc7695878e"
-
-[[projects]]
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
   revision = "0b12d6b5"
@@ -411,44 +185,6 @@
 
 [[projects]]
   branch = "master"
-  name = "github.com/keybase/go-crypto"
-  packages = [
-    "brainpool",
-    "cast5",
-    "curve25519",
-    "ed25519",
-    "ed25519/internal/edwards25519",
-    "openpgp",
-    "openpgp/armor",
-    "openpgp/ecdh",
-    "openpgp/elgamal",
-    "openpgp/errors",
-    "openpgp/packet",
-    "openpgp/s2k",
-    "rsa"
-  ]
-  revision = "8bab6ce2ea76875dcf28c287110f9cdf17fee30c"
-
-[[projects]]
-  name = "github.com/mattn/go-isatty"
-  packages = ["."]
-  revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
-  version = "v0.0.3"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/mitchellh/cli"
-  packages = ["."]
-  revision = "518dc677a1e1222682f4e7db06721942cb8e9e4c"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/mitchellh/copystructure"
-  packages = ["."]
-  revision = "d23ffcb85de31694d6ccaa23ccb4a03e55c1303f"
-
-[[projects]]
-  branch = "master"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
   revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
@@ -458,36 +194,6 @@
   name = "github.com/mitchellh/go-ps"
   packages = ["."]
   revision = "4fdf99ab29366514c69ccccddab5dc58b8d84062"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/mitchellh/go-testing-interface"
-  packages = ["."]
-  revision = "a61a99592b77c9ba629d254a693acffaeb4b7e28"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/mitchellh/go-wordwrap"
-  packages = ["."]
-  revision = "ad45545899c7b13c020ea92b2072220eefad42b8"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/mitchellh/hashstructure"
-  packages = ["."]
-  revision = "2bca23e0e452137f789efbc8610126fd8b94f73b"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/mitchellh/mapstructure"
-  packages = ["."]
-  revision = "a4e142e9c047c904fa2f1e144d9a84e6133024bc"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/mitchellh/reflectwalk"
-  packages = ["."]
-  revision = "63d60e9d0dbc60cf9164e6510889b0db6683d98c"
 
 [[projects]]
   name = "github.com/opentracing/opentracing-go"
@@ -518,20 +224,11 @@
   version = "v1.0.0"
 
 [[projects]]
-  name = "github.com/posener/complete"
-  packages = [
-    ".",
-    "cmd",
-    "cmd/install",
-    "match"
-  ]
-  revision = "dc2bc5a81accba8782bebea28628224643a8286a"
-  version = "v1.1"
-
-[[projects]]
+  branch = "master"
   name = "github.com/pulumi/pulumi"
   packages = [
     "pkg/apitype",
+    "pkg/apitype/migrate",
     "pkg/backend",
     "pkg/backend/local",
     "pkg/diag",
@@ -542,9 +239,9 @@
     "pkg/resource",
     "pkg/resource/config",
     "pkg/resource/deploy",
+    "pkg/resource/deploy/providers",
     "pkg/resource/graph",
     "pkg/resource/plugin",
-    "pkg/resource/provider",
     "pkg/resource/stack",
     "pkg/testing",
     "pkg/testing/integration",
@@ -565,19 +262,7 @@
     "pkg/workspace",
     "sdk/proto/go"
   ]
-  revision = "e1f34a842fbbe9806fde686c1064f83470eb5894"
-  version = "v0.14.0-rc1"
-
-[[projects]]
-  name = "github.com/pulumi/pulumi-aws"
-  packages = ["."]
-  revision = "9067b79c92640640f7a7a80655104a155d55799f"
-
-[[projects]]
-  name = "github.com/pulumi/pulumi-terraform"
-  packages = ["pkg/tfbridge"]
-  revision = "6f690f52a698c9a7638cea9c315760fd691f9c91"
-  version = "v0.7"
+  revision = "623e5f1be2dc96f0dcb17b846da464ee21e76b81"
 
 [[projects]]
   branch = "master"
@@ -627,12 +312,6 @@
   version = "v1.2.1"
 
 [[projects]]
-  name = "github.com/terraform-providers/terraform-provider-aws"
-  packages = ["aws"]
-  revision = "840a82babd3ef0deed25ca7e06104f998577bbab"
-  version = "v1.5.0"
-
-[[projects]]
   name = "github.com/uber/jaeger-client-go"
   packages = [
     ".",
@@ -656,17 +335,6 @@
   version = "v1.2.1"
 
 [[projects]]
-  name = "github.com/ulikunitz/xz"
-  packages = [
-    ".",
-    "internal/hash",
-    "internal/xlog",
-    "lzma"
-  ]
-  revision = "0c6b41e72360850ca4f98dc341fd999726ea007f"
-  version = "v0.5.4"
-
-[[projects]]
   branch = "master"
   name = "github.com/xanzy/ssh-agent"
   packages = ["."]
@@ -674,24 +342,8 @@
 
 [[projects]]
   branch = "master"
-  name = "github.com/zclconf/go-cty"
-  packages = [
-    "cty",
-    "cty/convert",
-    "cty/function",
-    "cty/function/stdlib",
-    "cty/gocty",
-    "cty/json",
-    "cty/set"
-  ]
-  revision = "709e4033eeb037dc543dbc2048065dfb814ce316"
-
-[[projects]]
-  branch = "master"
   name = "golang.org/x/crypto"
   packages = [
-    "bcrypt",
-    "blowfish",
     "cast5",
     "curve25519",
     "ed25519",
@@ -715,8 +367,6 @@
   name = "golang.org/x/net"
   packages = [
     "context",
-    "html",
-    "html/atom",
     "http2",
     "http2/hpack",
     "idna",
@@ -862,6 +512,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9d281e7d24886e2d6a28c7a210f69fa92afd0ed551db5c7c1fb5e925e440e90b"
+  inputs-digest = "735cdbef95cb717a15b549aab1259407396ab60f9a397a404788f027ee627677"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,8 +1,6 @@
-required = ["github.com/pulumi/pulumi-aws"]
-
-[[override]]
+[[constraint]]
   name = "github.com/pulumi/pulumi"
-  version = "v0.14.0-rc1"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/stretchr/testify"

--- a/nodejs/aws-infra/examples/cluster/package.json
+++ b/nodejs/aws-infra/examples/cluster/package.json
@@ -8,8 +8,8 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/aws": "^0.14.0-rc1",
-        "@pulumi/pulumi": "^0.14.0-rc1"
+        "@pulumi/aws": "^0.14.6-dev",
+        "@pulumi/pulumi": "^0.14.4-dev"
     },
     "devDependencies": {
         "@types/node": "^8.0.27",

--- a/nodejs/aws-infra/examples/cluster/yarn.lock
+++ b/nodejs/aws-infra/examples/cluster/yarn.lock
@@ -45,26 +45,28 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@pulumi/aws@^0.14.0-rc1":
-  version "0.14.0-rc1"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.14.0-rc1.tgz#212eb02e415c3e45ec920b79851d92e53e02f8c1"
+"@pulumi/aws@^0.14.6-dev":
+  version "0.14.6-dev-1533786302-g0daa086"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.14.6-dev-1533786302-g0daa086.tgz#b58298b6446252b2883d9b53b479ac7a8bd9b7b5"
   dependencies:
-    "@pulumi/pulumi" "^0.14.0-rc1"
+    "@pulumi/pulumi" "^0.14.4-dev"
     builtin-modules "3.0.0"
     read-package-tree "^5.2.1"
     resolve "^1.7.1"
 
-"@pulumi/pulumi@^0.14.0-rc1":
-  version "0.14.0-rc1"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.14.0-rc1.tgz#cf559d4e5f6b06e1918635990e0daa281b8e404f"
+"@pulumi/pulumi@^0.14.4-dev":
+  version "0.14.4-dev-1533786685-g80569fb5"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.14.4-dev-1533786685-g80569fb5.tgz#078a2e81e932bbc032a89d6668dce4670f6cc149"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"
     minimist "^1.2.0"
     protobufjs "^6.8.6"
+    read-package-tree "^5.2.1"
     require-from-string "^2.0.1"
     source-map-support "^0.4.16"
-    typescript "^2.5.2"
+    ts-node "^7.0.0"
+    typescript "^3.0.0"
 
 "@types/long@^3.0.32":
   version "3.0.32"
@@ -97,6 +99,10 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+arrify@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+
 asap@^2.0.0:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
@@ -118,6 +124,10 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+buffer-from@^1.0.0, buffer-from@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
 
 builtin-modules@3.0.0:
   version "3.0.0"
@@ -201,6 +211,10 @@ dezalgo@^1.0.0:
   dependencies:
     asap "^2.0.0"
     wrappy "1"
+
+diff@^3.1.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
 fs-minipass@^1.2.5:
   version "1.2.5"
@@ -329,6 +343,10 @@ long@^4.0.0:
 long@~3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
+
+make-error@^1.1.1:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.4.tgz#19978ed575f9e9545d2ff8c13e33b5d18a67d535"
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -609,9 +627,20 @@ source-map-support@^0.4.16:
   dependencies:
     source-map "^0.5.6"
 
+source-map-support@^0.5.6:
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.8.tgz#04f5581713a8a65612d0175fbf3a01f80a162613"
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 spdx-correct@^3.0.0:
   version "3.0.0"
@@ -671,13 +700,26 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
+ts-node@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.0.tgz#a94a13c75e5e1aa6b82814b84c68deb339ba7bff"
+  dependencies:
+    arrify "^1.0.0"
+    buffer-from "^1.1.0"
+    diff "^3.1.0"
+    make-error "^1.1.1"
+    minimist "^1.2.0"
+    mkdirp "^0.5.1"
+    source-map-support "^0.5.6"
+    yn "^2.0.0"
+
 typescript@^2.1.4:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
 
-typescript@^2.5.2:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
+typescript@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -730,3 +772,7 @@ yargs@^3.10.0:
     string-width "^1.0.1"
     window-size "^0.1.4"
     y18n "^3.2.0"
+
+yn@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"

--- a/nodejs/aws-infra/network.ts
+++ b/nodejs/aws-infra/network.ts
@@ -101,8 +101,10 @@ export class Network extends pulumi.ComponentResource implements ClusterNetworkA
         if (!defaultNetwork) {
             const vpc = aws.ec2.getVpc({default: true});
             const vpcId = vpc.then(v => v.id);
-            const subnetIds = aws.ec2.getSubnetIds({ vpcId: vpcId }).then(subnets => subnets.ids);
-            const defaultSecurityGroup = aws.ec2.getSecurityGroup({ name: "default", vpcId: vpcId }).then(sg => sg.id);
+            const subnetIds = vpcId.then(id => aws.ec2.getSubnetIds({ vpcId: id })).then(subnets => subnets.ids);
+            const defaultSecurityGroup = vpcId.then(id => aws.ec2.getSecurityGroup(
+                { name: "default", vpcId: id },
+            )).then(sg => sg.id);
             const subnet0 = subnetIds.then(ids => ids[0]);
             const subnet1 = subnetIds.then(ids => ids[1]);
 

--- a/nodejs/aws-infra/package.json
+++ b/nodejs/aws-infra/package.json
@@ -11,8 +11,8 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-aws-infra",
     "dependencies": {
-        "@pulumi/aws": "^0.14.0-rc1",
-        "@pulumi/pulumi": "^0.14.0-rc1"
+        "@pulumi/aws": "^0.14.6-dev",
+        "@pulumi/pulumi": "^0.14.4-dev"
     },
     "devDependencies": {
         "@types/aws-sdk": "^2.7.0",

--- a/nodejs/aws-infra/yarn.lock
+++ b/nodejs/aws-infra/yarn.lock
@@ -45,26 +45,28 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@pulumi/aws@^0.14.0-rc1":
-  version "0.14.0-rc1"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.14.0-rc1.tgz#212eb02e415c3e45ec920b79851d92e53e02f8c1"
+"@pulumi/aws@^0.14.6-dev":
+  version "0.14.6-dev-1533786302-g0daa086"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.14.6-dev-1533786302-g0daa086.tgz#b58298b6446252b2883d9b53b479ac7a8bd9b7b5"
   dependencies:
-    "@pulumi/pulumi" "^0.14.0-rc1"
+    "@pulumi/pulumi" "^0.14.4-dev"
     builtin-modules "3.0.0"
     read-package-tree "^5.2.1"
     resolve "^1.7.1"
 
-"@pulumi/pulumi@^0.14.0-rc1":
-  version "0.14.0-rc1"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.14.0-rc1.tgz#cf559d4e5f6b06e1918635990e0daa281b8e404f"
+"@pulumi/pulumi@^0.14.4-dev":
+  version "0.14.4-dev-1533786685-g80569fb5"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.14.4-dev-1533786685-g80569fb5.tgz#078a2e81e932bbc032a89d6668dce4670f6cc149"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"
     minimist "^1.2.0"
     protobufjs "^6.8.6"
+    read-package-tree "^5.2.1"
     require-from-string "^2.0.1"
     source-map-support "^0.4.16"
-    typescript "^2.5.2"
+    ts-node "^7.0.0"
+    typescript "^3.0.0"
 
 "@types/aws-sdk@^2.7.0":
   version "2.7.0"
@@ -180,6 +182,10 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+arrify@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+
 asap@^2.0.0:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
@@ -231,6 +237,10 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+buffer-from@^1.0.0, buffer-from@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
 
 buffer@4.9.1:
   version "4.9.1"
@@ -373,6 +383,10 @@ dezalgo@^1.0.0:
   dependencies:
     asap "^2.0.0"
     wrappy "1"
+
+diff@^3.1.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
 diff@^3.2.0:
   version "3.4.0"
@@ -604,6 +618,10 @@ long@~3:
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
+
+make-error@^1.1.1:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.4.tgz#19978ed575f9e9545d2ff8c13e33b5d18a67d535"
 
 marked@^0.3.17:
   version "0.3.19"
@@ -945,6 +963,13 @@ source-map-support@^0.4.16:
   dependencies:
     source-map "^0.5.6"
 
+source-map-support@^0.5.6:
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.8.tgz#04f5581713a8a65612d0175fbf3a01f80a162613"
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -954,6 +979,10 @@ source-map@^0.4.4:
 source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 spdx-correct@^3.0.0:
   version "3.0.0"
@@ -1027,6 +1056,19 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
+ts-node@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.0.tgz#a94a13c75e5e1aa6b82814b84c68deb339ba7bff"
+  dependencies:
+    arrify "^1.0.0"
+    buffer-from "^1.1.0"
+    diff "^3.1.0"
+    make-error "^1.1.1"
+    minimist "^1.2.0"
+    mkdirp "^0.5.1"
+    source-map-support "^0.5.6"
+    yn "^2.0.0"
+
 tslib@^1.8.0, tslib@^1.8.1:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
@@ -1084,13 +1126,13 @@ typescript@2.7.2:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
-typescript@^2.5.2:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
-
 typescript@^2.6.2:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
+
+typescript@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
 
 uglify-js@^2.6:
   version "2.8.29"
@@ -1205,3 +1247,7 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yn@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"


### PR DESCRIPTION
In preperation for 0.15.0-rc1, adopt the newest versions of some
packages from master and deal with the fallout (there was a breaking
change in @pulumi/aws that will be part of 0.15.0-rc1).