### PR TITLE
Update components to follow new design rules.

### DIFF
--- a/nodejs/aws-infra/cluster.ts
+++ b/nodejs/aws-infra/cluster.ts
@@ -132,18 +132,7 @@ export class Cluster extends pulumi.ComponentResource {
             throw new pulumi.RunError("Expected a valid Network to use for creating Cluster");
         }
 
-        super("aws-infra:cluster:Cluster", name, {
-            addEFS: args.addEFS,
-            instanceType: args.instanceType,
-            instanceRolePolicyARNs: args.instanceRolePolicyARNs,
-            instanceRootVolumeSize: args.instanceRootVolumeSize,
-            instanceDockerImageVolumeSize: args.instanceDockerImageVolumeSize,
-            instanceSwapVolumeSize: args.instanceSwapVolumeSize,
-            minSize: args.minSize,
-            maxSize: args.maxSize,
-            publicKey: args.publicKey,
-            ecsOptimizedAMIName: args.ecsOptimizedAMIName,
-        }, opts);
+        super("aws-infra:cluster:Cluster", name, {}, opts);
 
         this.network = args.network;
 
@@ -224,13 +213,7 @@ export class Cluster extends pulumi.ComponentResource {
                 this, name, args, instanceSecurityGroup, cluster, filesystem);
         }
 
-        this.registerOutputs({
-            network: this.network,
-            ecsClusterARN: this.ecsClusterARN,
-            securityGroupId: this.securityGroupId,
-            autoScalingGroupStack: this.autoScalingGroupStack,
-            efsMountPath: this.efsMountPath,
-        });
+        this.registerOutputs();
     }
 }
 

--- a/nodejs/aws-infra/experimental/ec2/securityGroup.ts
+++ b/nodejs/aws-infra/experimental/ec2/securityGroup.ts
@@ -28,21 +28,15 @@ export class SecurityGroup extends pulumi.ComponentResource {
     public readonly ingressRules: x.ec2.IngressSecurityGroupRule[] = [];
 
     constructor(name: string, args: SecurityGroupArgs, opts?: pulumi.ComponentResourceOptions) {
-        super("awsinfra:x:ec2:SecurityGroup", name, args, opts);
+        super("awsinfra:x:ec2:SecurityGroup", name, {}, opts);
 
-        const network = args.network || Network.getDefault();
-        const instance = args.instance || new aws.ec2.SecurityGroup(name, {
+        this.network = args.network || Network.getDefault();
+        this.instance = args.instance || new aws.ec2.SecurityGroup(name, {
             ...args,
-            vpcId: network.vpcId,
+            vpcId: this.network.vpcId,
         }, { parent: this });
 
-        this.instance = instance;
-        this.network = network;
-
-        this.registerOutputs({
-            instance,
-            network,
-        });
+        this.registerOutputs();
     }
 
     public createEgressRule(

--- a/nodejs/aws-infra/experimental/ec2/securityGroupRule.ts
+++ b/nodejs/aws-infra/experimental/ec2/securityGroupRule.ts
@@ -112,20 +112,15 @@ export abstract class SecurityGroupRule extends pulumi.ComponentResource {
     constructor(type: string, name: string,
                 securityGroup: x.ec2.SecurityGroup,
                 args: SecurityGroupRuleArgs, opts?: pulumi.ComponentResourceOptions) {
-        super(type, name, args, opts || { parent: securityGroup });
+        super(type, name, {}, opts || { parent: securityGroup });
 
-        const instance = new aws.ec2.SecurityGroupRule(name, {
+        this.securityGroup = securityGroup;
+        this.instance = new aws.ec2.SecurityGroupRule(name, {
             ...args,
             securityGroupId: securityGroup.instance.id,
         });
 
-        this.instance = instance;
-        this.securityGroup = securityGroup;
-
-        this.registerOutputs({
-            instance,
-            securityGroup,
-        });
+        this.registerOutputs();
     }
 
     public static egressArgs(

--- a/nodejs/aws-infra/experimental/ecs/ec2Service.ts
+++ b/nodejs/aws-infra/experimental/ecs/ec2Service.ts
@@ -40,6 +40,8 @@ export class EC2TaskDefinition extends ecs.TaskDefinition {
         delete (<any>argsCopy).container;
 
         super("awsinfra:x:ecs:EC2TaskDefinition", name, /*isFargate:*/ false, argsCopy, opts);
+
+        this.registerOutputs();
     }
 
     /**
@@ -62,7 +64,7 @@ export class EC2TaskDefinition extends ecs.TaskDefinition {
 }
 
 export class EC2Service extends ecs.Service {
-    public taskDefinitionInstance: EC2TaskDefinition;
+    public taskDefinition: EC2TaskDefinition;
 
     constructor(name: string,
                 args: EC2ServiceArgs,
@@ -87,7 +89,7 @@ export class EC2Service extends ecs.Service {
             },
         }, /*isFargate:*/ false, opts);
 
-        this.taskDefinitionInstance = taskDefinition;
+        this.registerOutputs();
     }
 }
 

--- a/nodejs/aws-infra/experimental/ecs/fargateService.ts
+++ b/nodejs/aws-infra/experimental/ecs/fargateService.ts
@@ -47,6 +47,8 @@ export class FargateTaskDefinition extends ecs.TaskDefinition {
         delete (<any>argsCopy).container;
 
         super("awsinfra:x:ecs:FargateTaskDefinition", name, /*isFargate:*/ true, argsCopy, opts);
+
+        this.registerOutputs();
     }
 
     /**
@@ -125,6 +127,8 @@ function computeFargateMemoryAndCPU(containers: Record<string, ecs.Container>) {
 }
 
 export class FargateService extends ecs.Service {
+    public readonly taskDefinition: FargateTaskDefinition;
+
     constructor(name: string,
                 args: FargateServiceArgs,
                 opts?: pulumi.ResourceOptions) {
@@ -147,6 +151,8 @@ export class FargateService extends ecs.Service {
                 subnets: cluster.network.subnetIds,
             },
         },  /*isFargate:*/ true, opts);
+
+        this.registerOutputs();
     }
 }
 

--- a/nodejs/aws-infra/experimental/ecs/service.ts
+++ b/nodejs/aws-infra/experimental/ecs/service.ts
@@ -22,8 +22,8 @@ import * as utils from "./../../utils";
 
 export abstract class Service extends pulumi.ComponentResource {
     public readonly instance: aws.ecs.Service;
-    public readonly clusterInstance: ecs.Cluster;
-    public readonly taskDefinitionInstance: ecs.TaskDefinition;
+    public readonly cluster: ecs.Cluster;
+    public readonly taskDefinition: ecs.TaskDefinition;
 
     constructor(type: string, name: string,
                 args: ServiceArgs, isFargate: boolean,
@@ -39,11 +39,11 @@ export abstract class Service extends pulumi.ComponentResource {
 
         const loadBalancers = getLoadBalancers(this, name, args);
 
-        const clusterInstance = args.cluster;
-        const instance = new aws.ecs.Service(name, {
+        this.cluster = args.cluster;
+        this.instance = new aws.ecs.Service(name, {
             ...args,
             loadBalancers,
-            cluster: clusterInstance.instance.arn,
+            cluster: this.cluster.instance.arn,
             taskDefinition: args.taskDefinition.instance.arn,
             desiredCount: utils.ifUndefined(args.desiredCount, 1),
             launchType: utils.ifUndefined(args.launchType, "EC2"),
@@ -51,17 +51,9 @@ export abstract class Service extends pulumi.ComponentResource {
             placementConstraints: pulumi.output(args.os).apply(os => placementConstraints(isFargate, os)),
         }, parentOpts);
 
-        const taskDefinitionInstance = args.taskDefinition;
+        this.taskDefinition = args.taskDefinition;
 
-        this.instance = instance;
-        this.clusterInstance = clusterInstance;
-        this.taskDefinitionInstance = args.taskDefinition;
-
-        this.registerOutputs({
-            instance,
-            clusterInstance,
-            taskDefinitionInstance,
-        });
+        this.registerOutputs();
     }
 }
 

--- a/nodejs/aws-infra/experimental/elasticloadbalancingv2/application.ts
+++ b/nodejs/aws-infra/experimental/elasticloadbalancingv2/application.ts
@@ -49,10 +49,7 @@ export class ApplicationLoadBalancer extends mod.LoadBalancer {
         this.listeners = [];
         this.targetGroups = [];
 
-        this.registerOutputs({
-            instance: this.instance,
-            network: this.network,
-        });
+        this.registerOutputs();
     }
 
     /**
@@ -96,14 +93,9 @@ export class ApplicationTargetGroup extends mod.TargetGroup {
         }, opts);
 
         this.loadBalancer = loadBalancer;
-
-        this.registerOutputs({
-            instance: this.instance,
-            network: this.network,
-            loadBalancer: this.loadBalancer,
-        });
-
         loadBalancer.targetGroups.push(this);
+
+        this.registerOutputs();
     }
 
     public createListener(name: string, args: ApplicationListenerArgs,
@@ -192,10 +184,7 @@ export class ApplicationListener extends mod.Listener {
         this.loadBalancer = loadBalancer;
         loadBalancer.listeners.push(this);
 
-        this.registerOutputs({
-            instance: this.instance,
-            loadBalancer: this.loadBalancer,
-        });
+        this.registerOutputs();
     }
 }
 

--- a/nodejs/aws-infra/experimental/elasticloadbalancingv2/listener.ts
+++ b/nodejs/aws-infra/experimental/elasticloadbalancingv2/listener.ts
@@ -45,20 +45,19 @@ export abstract class Listener
         const defaultSslPolicy = pulumi.output(args.certificateArn)
                                        .apply(a => a ? "ELBSecurityPolicy-2016-08" : undefined!);
 
-        const instance = new aws.elasticloadbalancingv2.Listener(name, {
+        this.instance = new aws.elasticloadbalancingv2.Listener(name, {
             ...args,
             loadBalancerArn: args.loadBalancer.instance.arn,
             sslPolicy: utils.ifUndefined(args.sslPolicy, defaultSslPolicy),
         }, parentOpts);
 
         const loadBalancer = args.loadBalancer.instance;
-        const endpoint = instance.urn.apply(_ => pulumi.output({
+        const endpoint = this.instance.urn.apply(_ => pulumi.output({
             hostname: loadBalancer.dnsName,
             loadBalancer: loadBalancer,
             port: args.port,
         }));
 
-        this.instance = instance;
         this.loadBalancer = args.loadBalancer;
         this.defaultListenerAction = defaultListenerAction;
 

--- a/nodejs/aws-infra/experimental/elasticloadbalancingv2/listenerRule.ts
+++ b/nodejs/aws-infra/experimental/elasticloadbalancingv2/listenerRule.ts
@@ -35,7 +35,7 @@ export class ListenerRule extends pulumi.ComponentResource {
 
     constructor(name: string, listener: x.elasticloadbalancingv2.Listener,
                 args: ListenerRuleArgs, opts?: pulumi.ComponentResourceOptions) {
-        super("awsinfra:x:elasticloadbalancingv2", name, args, opts || { parent: listener });
+        super("awsinfra:x:elasticloadbalancingv2", name, {}, opts || { parent: listener });
 
         const parentOpts = { parent: this };
         const actions = x.elasticloadbalancingv2.isListenerActions(args.actions)
@@ -54,6 +54,8 @@ export class ListenerRule extends pulumi.ComponentResource {
         if (x.elasticloadbalancingv2.isListenerActions(args.actions)) {
             args.actions.registerListener(listener);
         }
+
+        this.registerOutputs();
     }
 }
 

--- a/nodejs/aws-infra/experimental/elasticloadbalancingv2/network.ts
+++ b/nodejs/aws-infra/experimental/elasticloadbalancingv2/network.ts
@@ -38,10 +38,7 @@ export class NetworkLoadBalancer extends mod.LoadBalancer {
         this.listeners = [];
         this.targetGroups = [];
 
-        this.registerOutputs({
-            instance: this.instance,
-            network: this.network,
-        });
+        this.registerOutputs();
     }
 
     public createListener(name: string, args: NetworkListenerArgs, opts?: pulumi.ComponentResourceOptions) {
@@ -84,14 +81,9 @@ export class NetworkTargetGroup extends mod.TargetGroup {
         }, opts || { parent: loadBalancer });
 
         this.loadBalancer = loadBalancer;
-
-        this.registerOutputs({
-            instance: this.instance,
-            network: this.network,
-            loadBalancer: this.loadBalancer,
-        });
-
         loadBalancer.targetGroups.push(this);
+
+        this.registerOutputs();
     }
 
     public createListener(name: string, args: NetworkListenerArgs,
@@ -131,10 +123,7 @@ export class NetworkListener extends mod.Listener {
         this.loadBalancer = loadBalancer;
         loadBalancer.listeners.push(this);
 
-        this.registerOutputs({
-            instance: this.instance,
-            loadBalancer: this.loadBalancer,
-        });
+        this.registerOutputs();
     }
 }
 

--- a/nodejs/aws-infra/experimental/elasticloadbalancingv2/targetGroup.ts
+++ b/nodejs/aws-infra/experimental/elasticloadbalancingv2/targetGroup.ts
@@ -32,7 +32,7 @@ export abstract class TargetGroup
     public readonly listeners: x.elasticloadbalancingv2.Listener[] = [];
 
     constructor(type: string, name: string, args: TargetGroupArgs, opts?: pulumi.ComponentResourceOptions) {
-        super(type, name, args, opts);
+        super(type, name, {}, opts);
 
         const parentOpts = { parent: this };
 

--- a/nodejs/aws-infra/package.json
+++ b/nodejs/aws-infra/package.json
@@ -11,8 +11,8 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-aws-infra",
     "dependencies": {
-        "@pulumi/pulumi": "^0.16.8-dev",
-        "@pulumi/aws": "^0.16.4-dev",
+        "@pulumi/pulumi": "dev",
+        "@pulumi/aws": "dev",
         "@pulumi/docker": "^0.16.1"
     },
     "devDependencies": {


### PR DESCRIPTION
Update rules;

1. Components don't need to pass 'props' to super.  They can pass props, but they will be ignored.  To make this clearer, we explicitly pass `{}` down.
2. Non-abstract subclasses should call `.registerOutputs()` at the end of their constructor.  There is no need to pass arguments here.  Those are only needed for 'Stack' to register its exported outputs.