### PR TITLE
Adopt breaking change from AWS provider

### DIFF
--- a/nodejs/aws-infra/examples/ec2/package.json
+++ b/nodejs/aws-infra/examples/ec2/package.json
@@ -8,8 +8,8 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "dev",
-        "@pulumi/aws": "dev",
+        "@pulumi/pulumi": "latest",
+        "@pulumi/aws": "latest",
         "node-fetch": "^1.7.3",
         "redis": "^2.8.0"
     },

--- a/nodejs/aws-infra/examples/fargate/package.json
+++ b/nodejs/aws-infra/examples/fargate/package.json
@@ -8,8 +8,8 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "dev",
-        "@pulumi/aws": "dev",
+        "@pulumi/pulumi": "latest",
+        "@pulumi/aws": "latest",
         "node-fetch": "^1.7.3",
         "redis": "^2.8.0"
     },

--- a/nodejs/aws-infra/experimental/elasticloadbalancingv2/targetGroup.ts
+++ b/nodejs/aws-infra/experimental/elasticloadbalancingv2/targetGroup.ts
@@ -57,13 +57,13 @@ export abstract class TargetGroup
 
     public containerPortMappings(): pulumi.Input<pulumi.Input<aws.ecs.PortMapping>[]> {
         return pulumi.output([this.instance.port, this.dependencies()]).apply(([port]) => [{
-            containerPort: +port,
+            containerPort: +port!,
         }]);
     }
 
     public containerLoadBalancers(): pulumi.Input<pulumi.Input<x.ecs.ContainerLoadBalancer>[]> {
         return this.dependencies().apply(_ => [{
-            containerPort: this.instance.port,
+            containerPort: this.instance.port.apply(p => p!),
             targetGroupArn: this.instance.arn,
         }]);
     }

--- a/nodejs/aws-infra/package.json
+++ b/nodejs/aws-infra/package.json
@@ -11,8 +11,8 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-aws-infra",
     "dependencies": {
-        "@pulumi/pulumi": "dev",
-        "@pulumi/aws": "dev",
+        "@pulumi/pulumi": "^0.16.9",
+        "@pulumi/aws": "^0.16.5",
         "@pulumi/docker": "^0.16.1"
     },
     "devDependencies": {


### PR DESCRIPTION
The `port` property can now be undefined on aws TargetGroups when a Lambda is targetted.  It is not possible for the TargetGroup created by this wrapper to create the Lambda type yet though, so we can just assert the undefined away.

Also updates dependencies to fixed released versions for package and floating released versions for tests - instead of `dev`.

Fixes #83.