### PR TITLE
Accept ComponentResourceOptions

### DIFF
--- a/nodejs/aws-infra/cluster.ts
+++ b/nodejs/aws-infra/cluster.ts
@@ -127,7 +127,7 @@ export class Cluster extends pulumi.ComponentResource {
      */
     public readonly efsMountPath?: string;
 
-    constructor(name: string, args: ClusterArgs, opts?: pulumi.ResourceOptions) {
+    constructor(name: string, args: ClusterArgs, opts?: pulumi.ComponentResourceOptions) {
         if (!args.network) {
             throw new pulumi.RunError("Expected a valid Network to use for creating Cluster");
         }

--- a/nodejs/aws-infra/experimental/autoscaling/autoscaling.ts
+++ b/nodejs/aws-infra/experimental/autoscaling/autoscaling.ts
@@ -99,7 +99,7 @@ export class AutoScalingLaunchConfiguration extends pulumi.ComponentResource {
         name: string,
         assumeRolePolicy?: string | aws.iam.PolicyDocument,
         policyArns?: string[],
-        opts?: pulumi.ResourceOptions) {
+        opts?: pulumi.ComponentResourceOptions) {
 
         const { role, policies } = x.createRoleAndPolicies(
             name,

--- a/nodejs/aws-infra/experimental/ec2/vpc.ts
+++ b/nodejs/aws-infra/experimental/ec2/vpc.ts
@@ -76,7 +76,7 @@ export class Vpc extends pulumi.ComponentResource {
             const topology = new VpcTopology(this, name, cidrBlock, numberOfAvailabilityZones, opts);
             topology.createSubnets(args.subnets || [
                 { type: "public" },
-                { type: "private"},
+                { type: "private" },
             ]);
 
             // Create an internet gateway if we have public subnets.
@@ -117,14 +117,14 @@ export class Vpc extends pulumi.ComponentResource {
             return defaultVpc;
         }
 
-        const vpc = aws.ec2.getVpc({default: true});
+        const vpc = aws.ec2.getVpc({ default: true }, opts);
         const vpcId = vpc.then(v => v.id);
 
         // The default VPC will contain at least two public subnets (one per availability zone).
         // See https://docs.aws.amazon.com/vpc/latest/userguide/images/default-vpc-diagram.png for
         // more information.
         const subnetIds = vpcId.then(id => aws.ec2.getSubnetIds({ vpcId: id }))
-                               .then(subnets => subnets.ids);
+            .then(subnets => subnets.ids);
         const subnet0 = subnetIds.then(ids => ids[0]);
         const subnet1 = subnetIds.then(ids => ids[1]);
         const publicSubnetIds = [subnet0, subnet1];
@@ -135,7 +135,7 @@ export class Vpc extends pulumi.ComponentResource {
 
     public static fromExistingIds(name: string, idArgs: ExistingVpcIdArgs, opts?: pulumi.ComponentResourceOptions) {
         const vpc = new Vpc(name, {
-            instance: aws.ec2.Vpc.get(name, idArgs.vpcId),
+            instance: aws.ec2.Vpc.get(name, idArgs.vpcId, {}, opts),
         }, opts);
 
         createSubnets(vpc, "public", idArgs.publicSubnetIds);

--- a/nodejs/aws-infra/experimental/ecs/cluster.ts
+++ b/nodejs/aws-infra/experimental/ecs/cluster.ts
@@ -76,7 +76,7 @@ export class Cluster
     public createAutoScalingGroup(
             name: string,
             args?: x.autoscaling.AutoScalingGroupArgs,
-            opts?: pulumi.ResourceOptions) {
+            opts?: pulumi.ComponentResourceOptions) {
 
         args = args || { vpc: this.vpc };
 

--- a/nodejs/aws-infra/experimental/ecs/ec2Service.ts
+++ b/nodejs/aws-infra/experimental/ecs/ec2Service.ts
@@ -47,7 +47,7 @@ export class EC2TaskDefinition extends ecs.TaskDefinition {
     /**
      * Creates a service with this as its task definition.
      */
-    public createService(name: string, args: ecs.EC2ServiceArgs, opts?: pulumi.ResourceOptions) {
+    public createService(name: string, args: ecs.EC2ServiceArgs, opts?: pulumi.ComponentResourceOptions) {
         if (args.taskDefinition) {
             throw new Error("[args.taskDefinition] should not be provided.");
         }
@@ -68,7 +68,7 @@ export class EC2Service extends ecs.Service {
 
     constructor(name: string,
                 args: EC2ServiceArgs,
-                opts?: pulumi.ResourceOptions) {
+                opts?: pulumi.ComponentResourceOptions) {
 
         if (!args.taskDefinition && !args.taskDefinitionArgs) {
             throw new Error("Either [taskDefinition] or [taskDefinitionArgs] must be provided");

--- a/nodejs/aws-infra/experimental/ecs/fargateService.ts
+++ b/nodejs/aws-infra/experimental/ecs/fargateService.ts
@@ -55,7 +55,7 @@ export class FargateTaskDefinition extends ecs.TaskDefinition {
      * Creates a service with this as its task definition.
      */
     public createService(
-            name: string, args: ecs.FargateServiceArgs, opts?: pulumi.ResourceOptions) {
+            name: string, args: ecs.FargateServiceArgs, opts?: pulumi.ComponentResourceOptions) {
         if (args.taskDefinition) {
             throw new Error("[args.taskDefinition] should not be provided.");
         }
@@ -131,7 +131,7 @@ export class FargateService extends ecs.Service {
 
     constructor(name: string,
                 args: FargateServiceArgs,
-                opts?: pulumi.ResourceOptions) {
+                opts?: pulumi.ComponentResourceOptions) {
 
         if (!args.taskDefinition && !args.taskDefinitionArgs) {
             throw new Error("Either [taskDefinition] or [taskDefinitionArgs] must be provided");

--- a/nodejs/aws-infra/experimental/ecs/image.ts
+++ b/nodejs/aws-infra/experimental/ecs/image.ts
@@ -118,7 +118,7 @@ class AssetImage extends Image {
     }
 
     // getOrCreateRepository returns the ECR repository for this image, lazily allocating if necessary.
-    private getOrCreateRepository(imageName: string, opts: pulumi.ResourceOptions): aws.ecr.Repository {
+    private getOrCreateRepository(imageName: string, opts: pulumi.ComponentResourceOptions): aws.ecr.Repository {
         let repository: aws.ecr.Repository | undefined = AssetImage.repositories.get(imageName);
         if (!repository) {
             repository = new aws.ecr.Repository(imageName.toLowerCase(), {}, opts);

--- a/nodejs/aws-infra/experimental/ecs/service.ts
+++ b/nodejs/aws-infra/experimental/ecs/service.ts
@@ -27,7 +27,7 @@ export abstract class Service extends pulumi.ComponentResource {
 
     constructor(type: string, name: string,
                 args: ServiceArgs, isFargate: boolean,
-                opts: pulumi.ResourceOptions = {}) {
+                opts: pulumi.ComponentResourceOptions = {}) {
         super(type, name, args, opts);
 
         // If the cluster has any autoscaling groups, ensure the service depends on it being
@@ -112,7 +112,7 @@ function getLoadBalancers(service: ecs.Service, name: string, args: ServiceArgs)
 //     public readonly kind: cloud.VolumeKind;
 //     public readonly name: string;
 
-//     constructor(name: string, opts?: pulumi.ResourceOptions) {
+//     constructor(name: string, opts?: pulumi.ComponentResourceOptions) {
 //         if (volumeNames.has(name)) {
 //             throw new Error("Must provide a unique volume name");
 //         }

--- a/nodejs/aws-infra/experimental/ecs/taskDefinition.ts
+++ b/nodejs/aws-infra/experimental/ecs/taskDefinition.ts
@@ -135,7 +135,7 @@ export abstract class TaskDefinition extends pulumi.ComponentResource {
             name: string,
             assumeRolePolicy?: string | aws.iam.PolicyDocument,
             policyArns?: string[],
-            opts?: pulumi.ResourceOptions): aws.iam.Role {
+            opts?: pulumi.ComponentResourceOptions): aws.iam.Role {
 
         return x.createRole(
             name,
@@ -155,7 +155,7 @@ export abstract class TaskDefinition extends pulumi.ComponentResource {
             name: string,
             assumeRolePolicy?: string | aws.iam.PolicyDocument,
             policyArns?: string[],
-            opts?: pulumi.ResourceOptions): aws.iam.Role {
+            opts?: pulumi.ComponentResourceOptions): aws.iam.Role {
 
         return x.createRole(
             name,

--- a/nodejs/aws-infra/experimental/role.ts
+++ b/nodejs/aws-infra/experimental/role.ts
@@ -22,7 +22,7 @@ export function createRoleAndPolicies(
     name: string,
     assumeRolePolicy: string | aws.iam.PolicyDocument,
     policyArns: string[],
-    opts: pulumi.ResourceOptions | undefined) {
+    opts: pulumi.ComponentResourceOptions | undefined) {
 
     if (typeof assumeRolePolicy !== "string") {
         assumeRolePolicy = JSON.stringify(assumeRolePolicy);
@@ -45,7 +45,7 @@ export function createRole(
     name: string,
     assumeRolePolicy: string | aws.iam.PolicyDocument,
     policyArns: string[],
-    opts: pulumi.ResourceOptions | undefined) {
+    opts: pulumi.ComponentResourceOptions | undefined) {
 
     const { role } = createRoleAndPolicies(name, assumeRolePolicy, policyArns, opts);
     return role;

--- a/nodejs/aws-infra/network.ts
+++ b/nodejs/aws-infra/network.ts
@@ -118,7 +118,7 @@ export class Network extends pulumi.ComponentResource implements ClusterNetworkA
      * default network will be lazily created, using whatever options are provided in opts. All
      * subsequent calls will return that same network even if different opts are provided.
      */
-    public static getDefault(opts?: pulumi.ResourceOptions): Network {
+    public static getDefault(opts?: pulumi.ComponentResourceOptions): Network {
         if (!defaultNetwork) {
             const vpc = aws.ec2.getVpc({default: true});
             const vpcId = vpc.then(v => v.id);
@@ -144,7 +144,7 @@ export class Network extends pulumi.ComponentResource implements ClusterNetworkA
     /**
      * Creates a new network using the configuration values of an existing VPC.
      */
-    public static fromVpc(name: string, vpcArgs: NetworkVpcArgs, opts?: pulumi.ResourceOptions): Network {
+    public static fromVpc(name: string, vpcArgs: NetworkVpcArgs, opts?: pulumi.ComponentResourceOptions): Network {
         if (!vpcArgs.vpcId) {
             throw new RunError("vpcArgs.vpcId must be provided.");
         }
@@ -161,8 +161,8 @@ export class Network extends pulumi.ComponentResource implements ClusterNetworkA
         return new Network(name, vpcArgs, opts);
     }
 
-    constructor(name: string, args?: NetworkArgs, opts?: pulumi.ResourceOptions);
-    constructor(name: string, mergedArgs: NetworkArgs | NetworkVpcArgs = {}, opts: pulumi.ResourceOptions = {}) {
+    constructor(name: string, args?: NetworkArgs, opts?: pulumi.ComponentResourceOptions);
+    constructor(name: string, mergedArgs: NetworkArgs | NetworkVpcArgs = {}, opts: pulumi.ComponentResourceOptions = {}) {
         super("aws-infra:network:Network", name, {}, opts);
 
         // IDEA: default to the number of availability zones in this region, rather than 2.  To do this requires


### PR DESCRIPTION
Fix several places where we were not accepting a `ComponentResourceOptions` as needed to enable component-based provider chaining.