### PR TITLE
Rename 'instance' fields.

### DIFF
--- a/nodejs/aws-infra/examples/fargate/index.ts
+++ b/nodejs/aws-infra/examples/fargate/index.ts
@@ -319,7 +319,7 @@ const api = new aws.apigateway.x.API("examples-containers", {
 });
 
 export let frontendURL = api.url;
-export let vpcId = vpc.instance.id;
+export let vpcId = vpc.id;
 export let publicSubnets = vpc.publicSubnetIds;
 export let privateSubnets = vpc.privateSubnetIds;
 export let isolatedSubnets = vpc.isolatedSubnetIds;

--- a/nodejs/aws-infra/experimental/ec2/securityGroup.ts
+++ b/nodejs/aws-infra/experimental/ec2/securityGroup.ts
@@ -19,7 +19,8 @@ import * as x from "..";
 import * as utils from "./../../utils";
 
 export class SecurityGroup extends pulumi.ComponentResource {
-    public readonly instance: aws.ec2.SecurityGroup;
+    public readonly securityGroup: aws.ec2.SecurityGroup;
+    public readonly id: pulumi.Output<string>;
     public readonly vpc: x.ec2.Vpc;
 
     public readonly egressRules: x.ec2.IngressSecurityGroupRule[] = [];
@@ -32,10 +33,11 @@ export class SecurityGroup extends pulumi.ComponentResource {
         super("awsinfra:x:ec2:SecurityGroup", name, {}, opts);
 
         this.vpc = args.vpc || x.ec2.Vpc.getDefault();
-        this.instance = args.instance || new aws.ec2.SecurityGroup(name, {
+        this.securityGroup = args.securityGroup || new aws.ec2.SecurityGroup(name, {
             ...args,
-            vpcId: this.vpc.instance.id,
+            vpcId: this.vpc.id,
         }, { parent: this });
+        this.id = this.securityGroup.id;
 
         this.registerOutputs();
     }
@@ -51,7 +53,7 @@ export class SecurityGroup extends pulumi.ComponentResource {
 
         return new SecurityGroup(name, {
             ...args,
-            instance: aws.ec2.SecurityGroup.get(name, id, {}, opts),
+            securityGroup: aws.ec2.SecurityGroup.get(name, id, {}, opts),
         }, opts);
     }
 
@@ -79,6 +81,8 @@ export class SecurityGroup extends pulumi.ComponentResource {
     }
 }
 
+export type SecurityGroupOrId = SecurityGroup | pulumi.Input<string>;
+
 type OverwriteSecurityGroupArgs = utils.Overwrite<aws.ec2.SecurityGroupArgs, {
     name?: never;
     namePrefix?: never;
@@ -92,7 +96,7 @@ export interface SecurityGroupArgs {
      * An existing SecurityGroup to use for this awsinfra SecurityGroup.  If not provided, a default
      * one will be created.
      */
-    instance?: aws.ec2.SecurityGroup;
+    securityGroup?: aws.ec2.SecurityGroup;
 
     /**
      * The vpc this security group applies to.  Or [Network.getDefault] if unspecified.

--- a/nodejs/aws-infra/experimental/ec2/securityGroupRule.ts
+++ b/nodejs/aws-infra/experimental/ec2/securityGroupRule.ts
@@ -104,7 +104,7 @@ export class AllTraffic implements SecurityGroupRulePorts {
 }
 
 export abstract class SecurityGroupRule extends pulumi.ComponentResource {
-    public readonly instance: aws.ec2.SecurityGroupRule;
+    public readonly securityGroupRule: aws.ec2.SecurityGroupRule;
     public readonly securityGroup: x.ec2.SecurityGroup;
 
     constructor(type: string, name: string,
@@ -113,9 +113,9 @@ export abstract class SecurityGroupRule extends pulumi.ComponentResource {
         super(type, name, {}, opts || { parent: securityGroup });
 
         this.securityGroup = securityGroup;
-        this.instance = new aws.ec2.SecurityGroupRule(name, {
+        this.securityGroupRule = new aws.ec2.SecurityGroupRule(name, {
             ...args,
-            securityGroupId: securityGroup.instance.id,
+            securityGroupId: securityGroup.id,
         });
 
         this.registerOutputs();

--- a/nodejs/aws-infra/experimental/ec2/vpcTopology.ts
+++ b/nodejs/aws-infra/experimental/ec2/vpcTopology.ts
@@ -120,7 +120,7 @@ ${lastAllocatedIpAddress} > ${lastVpcIpAddress}`);
             }, this.opts);
 
             subnets.push(subnet);
-            subnetIds.push(subnet.subnetId);
+            subnetIds.push(subnet.id);
         }
 
         return;

--- a/nodejs/aws-infra/experimental/ecs/ec2Service.ts
+++ b/nodejs/aws-infra/experimental/ecs/ec2Service.ts
@@ -88,7 +88,7 @@ export class EC2Service extends ecs.Service {
             networkConfiguration: {
                 subnets,
                 assignPublicIp: false,
-                securityGroups: securityGroups.map(g => g.instance.id),
+                securityGroups: securityGroups.map(g => g.id),
             },
         }, /*isFargate:*/ false, opts);
 

--- a/nodejs/aws-infra/experimental/ecs/fargateService.ts
+++ b/nodejs/aws-infra/experimental/ecs/fargateService.ts
@@ -152,7 +152,7 @@ export class FargateService extends ecs.Service {
             networkConfiguration: {
                 subnets,
                 assignPublicIp,
-                securityGroups: securityGroups.map(g => g.instance.id),
+                securityGroups: securityGroups.map(g => g.id),
             },
         },  /*isFargate:*/ true, opts);
 

--- a/nodejs/aws-infra/experimental/ecs/service.ts
+++ b/nodejs/aws-infra/experimental/ecs/service.ts
@@ -21,7 +21,7 @@ import * as x from "..";
 import * as utils from "./../../utils";
 
 export abstract class Service extends pulumi.ComponentResource {
-    public readonly instance: aws.ecs.Service;
+    public readonly service: aws.ecs.Service;
     public readonly cluster: ecs.Cluster;
     public readonly taskDefinition: ecs.TaskDefinition;
 
@@ -40,11 +40,11 @@ export abstract class Service extends pulumi.ComponentResource {
         const loadBalancers = getLoadBalancers(this, name, args);
 
         this.cluster = args.cluster;
-        this.instance = new aws.ecs.Service(name, {
+        this.service = new aws.ecs.Service(name, {
             ...args,
             loadBalancers,
-            cluster: this.cluster.instance.arn,
-            taskDefinition: args.taskDefinition.instance.arn,
+            cluster: this.cluster.cluster.arn,
+            taskDefinition: args.taskDefinition.taskDefinition.arn,
             desiredCount: utils.ifUndefined(args.desiredCount, 1),
             launchType: utils.ifUndefined(args.launchType, "EC2"),
             waitForSteadyState: utils.ifUndefined(args.waitForSteadyState, true),

--- a/nodejs/aws-infra/experimental/ecs/taskDefinition.ts
+++ b/nodejs/aws-infra/experimental/ecs/taskDefinition.ts
@@ -23,7 +23,7 @@ import * as ecs from ".";
 import * as x from "..";
 
 export abstract class TaskDefinition extends pulumi.ComponentResource {
-    public readonly instance: aws.ecs.TaskDefinition;
+    public readonly taskDefinition: aws.ecs.TaskDefinition;
     public readonly logGroup: aws.cloudwatch.LogGroup;
     public readonly containers: Record<string, ecs.Container>;
     public readonly taskRole: aws.iam.Role;
@@ -78,7 +78,7 @@ export abstract class TaskDefinition extends pulumi.ComponentResource {
         const containerString = containerDefinitions.apply(JSON.stringify);
         const family = containerString.apply(s => name + "-" + utils.sha1hash(pulumi.getStack() + containerString));
 
-        this.instance = new aws.ecs.TaskDefinition(name, {
+        this.taskDefinition = new aws.ecs.TaskDefinition(name, {
             ...args,
             family,
             taskRoleArn: this.taskRole.arn,
@@ -86,7 +86,7 @@ export abstract class TaskDefinition extends pulumi.ComponentResource {
             containerDefinitions: containerString,
         }, parentOpts);
 
-        this.run = createRunFunction(isFargate, this.instance.arn);
+        this.run = createRunFunction(isFargate, this.taskDefinition.arn);
 
         this.registerOutputs();
     }
@@ -226,8 +226,8 @@ function createRunFunction(isFargate: boolean, taskDefArn: pulumi.Output<string>
         const ecs = new aws.sdk.ECS();
 
         const cluster = params.cluster;
-        const clusterArn = cluster.instance.id.get();
-        const securityGroupIds = cluster.securityGroups.map(g => g.instance.id.get());
+        const clusterArn = cluster.id.get();
+        const securityGroupIds = cluster.securityGroups.map(g => g.id.get());
         const subnetIds = cluster.vpc.publicSubnetIds.map(i => i.get());
         const assignPublicIp = isFargate; // && !usePrivateSubnets;
 

--- a/nodejs/aws-infra/experimental/elasticloadbalancingv2/listener.ts
+++ b/nodejs/aws-infra/experimental/elasticloadbalancingv2/listener.ts
@@ -23,7 +23,7 @@ import * as utils from "./../../utils";
 export abstract class Listener
         extends pulumi.ComponentResource
         implements x.ecs.ContainerPortMappings {
-    public readonly instance: aws.elasticloadbalancingv2.Listener;
+    public readonly listener: aws.elasticloadbalancingv2.Listener;
     public readonly loadBalancer: x.elasticloadbalancingv2.LoadBalancer;
 
     public readonly endpoint: () => pulumi.Output<aws.apigateway.x.Endpoint>;
@@ -43,14 +43,14 @@ export abstract class Listener
         const defaultSslPolicy = pulumi.output(args.certificateArn)
                                        .apply(a => a ? "ELBSecurityPolicy-2016-08" : undefined!);
 
-        this.instance = new aws.elasticloadbalancingv2.Listener(name, {
+        this.listener = new aws.elasticloadbalancingv2.Listener(name, {
             ...args,
-            loadBalancerArn: args.loadBalancer.instance.arn,
+            loadBalancerArn: args.loadBalancer.loadBalancer.arn,
             sslPolicy: utils.ifUndefined(args.sslPolicy, defaultSslPolicy),
         }, parentOpts);
 
-        const loadBalancer = args.loadBalancer.instance;
-        const endpoint = this.instance.urn.apply(_ => pulumi.output({
+        const loadBalancer = args.loadBalancer.loadBalancer;
+        const endpoint = this.listener.urn.apply(_ => pulumi.output({
             hostname: loadBalancer.dnsName,
             loadBalancer: loadBalancer,
             port: args.port,

--- a/nodejs/aws-infra/experimental/elasticloadbalancingv2/listenerRule.ts
+++ b/nodejs/aws-infra/experimental/elasticloadbalancingv2/listenerRule.ts
@@ -29,7 +29,7 @@ import * as utils from "./../../utils";
  * https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-update-rules.html
  */
 export class ListenerRule extends pulumi.ComponentResource {
-    public readonly instance: aws.elasticloadbalancingv2.ListenerRule;
+    public readonly listenerRule: aws.elasticloadbalancingv2.ListenerRule;
 
     constructor(name: string, listener: x.elasticloadbalancingv2.Listener,
                 args: ListenerRuleArgs, opts?: pulumi.ComponentResourceOptions) {
@@ -40,10 +40,10 @@ export class ListenerRule extends pulumi.ComponentResource {
             ? args.actions.actions()
             : args.actions;
 
-        this.instance = new aws.elasticloadbalancingv2.ListenerRule(name, {
+        this.listenerRule = new aws.elasticloadbalancingv2.ListenerRule(name, {
             ...args,
             actions,
-            listenerArn: listener.instance.arn,
+            listenerArn: listener.listener.arn,
         }, parentOpts);
 
         // If this is a rule hooking up this listener to a target group, then add our listener to

--- a/nodejs/aws-infra/experimental/elasticloadbalancingv2/loadBalancer.ts
+++ b/nodejs/aws-infra/experimental/elasticloadbalancingv2/loadBalancer.ts
@@ -19,7 +19,7 @@ import * as x from "..";
 import * as utils from "./../../utils";
 
 export abstract class LoadBalancer extends pulumi.ComponentResource {
-    public readonly instance: aws.elasticloadbalancingv2.LoadBalancer;
+    public readonly loadBalancer: aws.elasticloadbalancingv2.LoadBalancer;
     public readonly vpc: x.ec2.Vpc;
     public readonly securityGroups: x.ec2.SecurityGroup[];
 
@@ -35,11 +35,11 @@ export abstract class LoadBalancer extends pulumi.ComponentResource {
         this.securityGroups = args.securityGroups || [];
 
         const external = utils.ifUndefined(args.external, true);
-        this.instance = new aws.elasticloadbalancingv2.LoadBalancer(shortName, {
+        this.loadBalancer = new aws.elasticloadbalancingv2.LoadBalancer(shortName, {
             ...args,
             subnets: getSubnets(args, this.vpc, external),
             internal: external.apply(ex => !ex),
-            securityGroups: this.securityGroups.map(g => g.instance.id),
+            securityGroups: this.securityGroups.map(g => g.id),
             tags: utils.mergeTags(args.tags, { Name: longName }),
         }, parentOpts);
    }


### PR DESCRIPTION
1. Use a name that matches the underlying resource type instead of 'instance'.
2. Elevate commonly accessed 'id' properties to component resource.