### PR TITLE
Use a consistent approach to security groups.

### DIFF
--- a/nodejs/aws-infra/experimental/ec2/securityGroup.ts
+++ b/nodejs/aws-infra/experimental/ec2/securityGroup.ts
@@ -79,6 +79,32 @@ export class SecurityGroup extends pulumi.ComponentResource {
     }
 }
 
+export type SecurityGroupOrId = SecurityGroup | pulumi.Input<string>;
+
+/** @internal */
+export function getSecurityGroups(
+        vpc: x.ec2.Vpc, name: string, args: SecurityGroupOrId[] | undefined,
+        opts: pulumi.ResourceOptions | undefined) {
+    if (!args) {
+        return undefined;
+    }
+
+    const result: x.ec2.SecurityGroup[] = [];
+    for (let i = 0, n = args.length; i < n; i++) {
+        const obj = args[i];
+        if (x.ec2.SecurityGroup.isSecurityGroupInstance(obj)) {
+            result.push(obj);
+        }
+        else {
+            result.push(x.ec2.SecurityGroup.fromExistingId(`${name}-${i}`, obj, {
+                vpc,
+            }, opts));
+        }
+    }
+
+    return result;
+}
+
 type OverwriteSecurityGroupArgs = utils.Overwrite<aws.ec2.SecurityGroupArgs, {
     name?: never;
     namePrefix?: never;

--- a/nodejs/aws-infra/experimental/ecs/service.ts
+++ b/nodejs/aws-infra/experimental/ecs/service.ts
@@ -24,6 +24,7 @@ export abstract class Service extends pulumi.ComponentResource {
     public readonly instance: aws.ecs.Service;
     public readonly cluster: ecs.Cluster;
     public readonly taskDefinition: ecs.TaskDefinition;
+    public readonly securityGroups: x.ec2.SecurityGroup[];
 
     constructor(type: string, name: string,
                 args: ServiceArgs, isFargate: boolean,
@@ -160,6 +161,7 @@ export function isServiceLoadBalancers(obj: any): obj is ServiceLoadBalancers {
 type OverwriteShape = utils.Overwrite<utils.Mutable<aws.ecs.ServiceArgs>, {
     cluster: ecs.Cluster;
     taskDefinition: ecs.TaskDefinition;
+    securityGroups: x.ec2.SecurityGroup[];
     desiredCount?: pulumi.Input<number>;
     launchType?: pulumi.Input<"EC2" | "FARGATE">;
     os?: pulumi.Input<"linux" | "windows">;
@@ -257,6 +259,11 @@ export interface ServiceArgs {
      * The task definition to create the service from.
      */
     taskDefinition: ecs.TaskDefinition;
+
+    /**
+     * Security groups determining how this service can be reached.
+     */
+    securityGroups: x.ec2.SecurityGroup[];
 
     /**
      * The number of instances of the task definition to place and keep running. Defaults to 1. Do

--- a/nodejs/aws-infra/experimental/elasticloadbalancingv2/application.ts
+++ b/nodejs/aws-infra/experimental/elasticloadbalancingv2/application.ts
@@ -275,7 +275,7 @@ export interface ApplicationLoadBalancerArgs {
     /**
      * A list of security group IDs to assign to the LB.
      */
-    securityGroups?: x.ec2.SecurityGroup[];
+    securityGroups?: x.ec2.SecurityGroupOrId[];
 }
 
 export interface ApplicationTargetGroupArgs {

--- a/nodejs/aws-infra/experimental/elasticloadbalancingv2/loadBalancer.ts
+++ b/nodejs/aws-infra/experimental/elasticloadbalancingv2/loadBalancer.ts
@@ -32,7 +32,7 @@ export abstract class LoadBalancer extends pulumi.ComponentResource {
         const parentOpts = { parent: this };
 
         this.vpc = args.vpc || x.ec2.Vpc.getDefault();
-        this.securityGroups = args.securityGroups || [];
+        this.securityGroups = x.ec2.getSecurityGroups(this.vpc, name, args.securityGroups, parentOpts) || [];
 
         const external = utils.ifUndefined(args.external, true);
         this.instance = new aws.elasticloadbalancingv2.LoadBalancer(shortName, {
@@ -120,7 +120,7 @@ export interface LoadBalancerArgs {
      * A list of security group IDs to assign to the LB. Only valid for Load Balancers of type
      * `application`.
      */
-    securityGroups?: x.ec2.SecurityGroup[];
+    securityGroups?: x.ec2.SecurityGroupOrId[];
 }
 
 export interface LoadBalancerSubnets {


### PR DESCRIPTION
This approach was introduced in https://github.com/pulumi/pulumi-aws-infra/commit/f45138ffc6a8a920aecb6195836c09bcc3864ceb.  However, it was not applied uniformly to all of aws-infra.  This PR does that.