### PR TITLE
Switch callback-interfaces to produce individual items, not arrays.

### DIFF
--- a/nodejs/aws-infra/examples/ec2/index.ts
+++ b/nodejs/aws-infra/examples/ec2/index.ts
@@ -12,15 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as pulumi from "@pulumi/pulumi";
-
 import * as aws from "@pulumi/aws";
 import * as awsinfra from "@pulumi/aws-infra";
 
 const x = awsinfra.x;
 
-import { Config, Output } from "@pulumi/pulumi";
-
+import { Config } from "@pulumi/pulumi";
 
 const vpc = x.ec2.Vpc.getDefault();
 const cluster = new x.ecs.Cluster("testing", { vpc });
@@ -42,7 +39,7 @@ const nginx = new x.ecs.EC2Service("examples-nginx", {
             nginx: {
                 image: "nginx",
                 memory: 128,
-                portMappings: nginxListener,
+                portMappings: [nginxListener],
             },
         },
     },
@@ -57,7 +54,7 @@ const simpleNginx = new x.ecs.EC2TaskDefinition("examples-simple-nginx", {
     container: {
         image: "nginx",
         memory: 128,
-        portMappings: simpleNginxListener,
+        portMappings: [simpleNginxListener],
     },
 }).createService("examples-simple-nginx", { cluster, desiredCount: 2});
 
@@ -73,7 +70,8 @@ const cachedNginx = new x.ecs.EC2Service("examples-cached-nginx", {
                     cacheFrom: true,
                 }),
                 memory: 128,
-                portMappings: new x.elasticloadbalancingv2.NetworkListener("examples-cached-nginx", { port: 80 }),
+                portMappings: [new x.elasticloadbalancingv2.NetworkListener(
+                    "examples-cached-nginx", { port: 80 })],
             },
         },
     },
@@ -91,8 +89,8 @@ const multistageCachedNginx = new x.ecs.EC2Service("examples-multistage-cached-n
                     cacheFrom: {stages: ["build"]},
                 }),
                 memory: 128,
-                portMappings: new x.elasticloadbalancingv2.NetworkListener(
-                    "examples-multistage-cached-nginx", { port: 80 }),
+                portMappings: [new x.elasticloadbalancingv2.NetworkListener(
+                    "examples-multistage-cached-nginx", { port: 80 })],
             },
         },
     },
@@ -109,7 +107,7 @@ const customWebServer = new x.ecs.EC2Service("custom", {
         containers: {
             webserver: {
                 memory: 128,
-                portMappings: customWebServerListener,
+                portMappings: [customWebServerListener],
                 image: x.ecs.Image.fromFunction(() => {
                     const rand = Math.random();
                     const http = require("http");
@@ -142,7 +140,7 @@ class Cache {
                     redis: {
                         image: "redis:alpine",
                         memory: memory,
-                        portMappings: redisListener,
+                        portMappings: [redisListener],
                         command: ["redis-server", "--requirepass", redisPassword],
                     },
                 },
@@ -208,7 +206,7 @@ const builtService = new x.ecs.EC2Service("examples-nginx2", {
             nginx: {
                 image: x.ecs.Image.fromPath("./app"),
                 memory: 128,
-                portMappings: builtServiceListener,
+                portMappings: [builtServiceListener],
             },
         },
     },

--- a/nodejs/aws-infra/examples/fargate/index.ts
+++ b/nodejs/aws-infra/examples/fargate/index.ts
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as pulumi from "@pulumi/pulumi";
-
 import * as aws from "@pulumi/aws";
 import * as awsinfra from "@pulumi/aws-infra";
 const x = awsinfra.x;
 
-import { Config, Output } from "@pulumi/pulumi";
+import { Config } from "@pulumi/pulumi";
 
 const vpc = x.ec2.Vpc.getDefault();
 const cluster = new x.ecs.Cluster("testing", { vpc });
@@ -32,7 +30,7 @@ const nginx = new x.ecs.FargateService("examples-nginx", {
             nginx: {
                 image: "nginx",
                 memory: 128,
-                portMappings: nginxListener,
+                portMappings: [nginxListener],
             },
         },
     },
@@ -47,7 +45,7 @@ const simpleNginx = new x.ecs.FargateTaskDefinition("examples-simple-nginx", {
     container: {
         image: "nginx",
         memory: 128,
-        portMappings: simpleNginxListener,
+        portMappings: [simpleNginxListener],
     },
 }).createService("examples-simple-nginx", { cluster, desiredCount: 2});
 
@@ -63,7 +61,7 @@ const cachedNginx = new x.ecs.FargateService("examples-cached-nginx", {
                     cacheFrom: true,
                 }),
                 memory: 128,
-                portMappings: new x.elasticloadbalancingv2.NetworkListener("examples-cached-nginx", { port: 80 }),
+                portMappings: [new x.elasticloadbalancingv2.NetworkListener("examples-cached-nginx", { port: 80 })],
             },
         },
     },
@@ -81,8 +79,8 @@ const multistageCachedNginx = new x.ecs.FargateService("examples-multistage-cach
                     cacheFrom: {stages: ["build"]},
                 }),
                 memory: 128,
-                portMappings: new x.elasticloadbalancingv2.NetworkListener(
-                    "examples-multistage-cached-nginx", { port: 80 }),
+                portMappings: [new x.elasticloadbalancingv2.NetworkListener(
+                    "examples-multistage-cached-nginx", { port: 80 })],
             },
         },
     },
@@ -99,7 +97,7 @@ const customWebServer = new x.ecs.FargateService("mycustomservice", {
         containers: {
             webserver: {
                 memory: 128,
-                portMappings: customWebServerListener,
+                portMappings: [customWebServerListener],
                 image: x.ecs.Image.fromFunction(() => {
                     const rand = Math.random();
                     const http = require("http");
@@ -132,7 +130,7 @@ class Cache {
                     redis: {
                         image: "redis:alpine",
                         memory: memory,
-                        portMappings: redisListener,
+                        portMappings: [redisListener],
                         command: ["redis-server", "--requirepass", redisPassword],
                     },
                 },
@@ -198,7 +196,7 @@ const builtService = new x.ecs.FargateService("examples-nginx2", {
             nginx: {
                 image: x.ecs.Image.fromPath("./app"),
                 memory: 128,
-                portMappings: builtServiceListener,
+                portMappings: [builtServiceListener],
             },
         },
     },

--- a/nodejs/aws-infra/experimental/ecs/cluster.ts
+++ b/nodejs/aws-infra/experimental/ecs/cluster.ts
@@ -104,28 +104,28 @@ export class Cluster
             tags: { Name: name },
         }, opts);
 
-        Cluster.createDefaultSecurityGroupEgressRules(securityGroup);
-        Cluster.createDefaultSecurityGroupIngressRules(securityGroup);
+        Cluster.createDefaultSecurityGroupEgressRules(name, securityGroup);
+        Cluster.createDefaultSecurityGroupIngressRules(name, securityGroup);
 
         return securityGroup;
     }
 
-    public static createDefaultSecurityGroupEgressRules(securityGroup: x.ec2.SecurityGroup) {
-        return [x.ec2.SecurityGroupRule.egress("egress", securityGroup,
+    public static createDefaultSecurityGroupEgressRules(name: string, securityGroup: x.ec2.SecurityGroup) {
+        return [x.ec2.SecurityGroupRule.egress(`${name}-egress`, securityGroup,
             new x.ec2.AnyIPv4Location(),
             new x.ec2.AllTraffic(),
             "allow output to any ipv4 address using any protocol")];
     }
 
-    public static createDefaultSecurityGroupIngressRules(securityGroup: x.ec2.SecurityGroup) {
-        return [x.ec2.SecurityGroupRule.ingress("ssh", securityGroup,
+    public static createDefaultSecurityGroupIngressRules(name: string, securityGroup: x.ec2.SecurityGroup) {
+        return [x.ec2.SecurityGroupRule.ingress(`${name}-ssh`, securityGroup,
                     new x.ec2.AnyIPv4Location(),
                     new x.ec2.TcpPorts(22),
                     "allow ssh in from any ipv4 address"),
 
                 // Expose ephemeral container ports to Internet.
                 // TODO: Limit to load balancer(s).
-                x.ec2.SecurityGroupRule.ingress("containers", securityGroup,
+                x.ec2.SecurityGroupRule.ingress(`${name}-containers`, securityGroup,
                     new x.ec2.AnyIPv4Location(),
                     new x.ec2.AllTcpPorts(),
                     "allow incoming tcp on any port from any ipv4 address")];

--- a/nodejs/aws-infra/experimental/ecs/ec2Service.ts
+++ b/nodejs/aws-infra/experimental/ecs/ec2Service.ts
@@ -210,7 +210,7 @@ export interface EC2ServiceArgs {
     /**
      * A load balancer block. Load balancers documented below.
      */
-    loadBalancers?: aws.ecs.ServiceArgs["loadBalancers"] | x.ecs.ServiceLoadBalancers;
+    loadBalancers?: (pulumi.Input<x.ecs.ServiceLoadBalancer> | x.ecs.ServiceLoadBalancerProvider)[];
 
     /**
      * The name of the service (up to 255 letters, numbers, hyphens, and underscores)

--- a/nodejs/aws-infra/experimental/ecs/fargateService.ts
+++ b/nodejs/aws-infra/experimental/ecs/fargateService.ts
@@ -277,7 +277,7 @@ export interface FargateServiceArgs {
     /**
      * A load balancer block. Load balancers documented below.
      */
-    loadBalancers?: aws.ecs.ServiceArgs["loadBalancers"] | x.ecs.ServiceLoadBalancers;
+    loadBalancers?: (pulumi.Input<x.ecs.ServiceLoadBalancer> | x.ecs.ServiceLoadBalancerProvider)[];
 
     /**
      * The name of the service (up to 255 letters, numbers, hyphens, and underscores)

--- a/nodejs/aws-infra/experimental/elasticloadbalancingv2/listener.ts
+++ b/nodejs/aws-infra/experimental/elasticloadbalancingv2/listener.ts
@@ -22,7 +22,7 @@ import * as utils from "./../../utils";
 
 export abstract class Listener
         extends pulumi.ComponentResource
-        implements x.ecs.ContainerPortMappings {
+        implements x.ecs.PortMappingProvider, x.ecs.ContainerLoadBalancerProvider {
     public readonly listener: aws.elasticloadbalancingv2.Listener;
     public readonly loadBalancer: x.elasticloadbalancingv2.LoadBalancer;
 
@@ -70,20 +70,20 @@ export abstract class Listener
         this.endpoint = () => endpoint;
     }
 
-    public containerPortMappings() {
-        if (!x.ecs.isContainerPortMappings(this.defaultListenerAction)) {
-            throw new Error("[Listener] was not connected to a [defaultAction] that can provide [containerPortMappings]");
+    public portMapping() {
+        if (!x.ecs.isPortMappingProvider(this.defaultListenerAction)) {
+            throw new Error("[Listener] was not connected to a [defaultAction] that can provide [portMapping]s");
         }
 
-        return this.defaultListenerAction.containerPortMappings();
+        return this.defaultListenerAction.portMapping();
     }
 
-    public containerLoadBalancers() {
-        if (!x.ecs.isContainerPortMappings(this.defaultListenerAction)) {
-            throw new Error("[Listener] was not connected to a [defaultAction] that can provide [containerPortMappings]");
+    public containerLoadBalancer() {
+        if (!x.ecs.isContainerLoadBalancerProvider(this.defaultListenerAction)) {
+            throw new Error("[Listener] was not connected to a [defaultAction] that can provide [containerLoadBalancer]s");
         }
 
-        return this.defaultListenerAction.containerLoadBalancers();
+        return this.defaultListenerAction.containerLoadBalancer();
     }
 
     public addListenerRule(name: string, args: x.elasticloadbalancingv2.ListenerRuleArgs, opts?: pulumi.ComponentResourceOptions) {

--- a/nodejs/aws-infra/experimental/elasticloadbalancingv2/targetGroup.ts
+++ b/nodejs/aws-infra/experimental/elasticloadbalancingv2/targetGroup.ts
@@ -23,7 +23,9 @@ import * as utils from "./../../utils";
 
 export abstract class TargetGroup
         extends pulumi.ComponentResource
-        implements x.ecs.ContainerPortMappings, x.elasticloadbalancingv2.ListenerDefaultAction {
+        implements x.ecs.PortMappingProvider,
+                   x.ecs.ContainerLoadBalancerProvider,
+                   x.elasticloadbalancingv2.ListenerDefaultAction {
 
     public readonly targetGroup: aws.elasticloadbalancingv2.TargetGroup;
     public readonly vpc: x.ec2.Vpc;
@@ -55,17 +57,17 @@ export abstract class TargetGroup
         return pulumi.output(this.listeners.map(r => r.listener.urn));
     }
 
-    public containerPortMappings(): pulumi.Input<pulumi.Input<aws.ecs.PortMapping>[]> {
-        return pulumi.output([this.targetGroup.port, this.dependencies()]).apply(([port]) => [{
+    public portMapping(): pulumi.Input<aws.ecs.PortMapping> {
+        return pulumi.output([this.targetGroup.port, this.dependencies()]).apply(([port]) => ({
             containerPort: +port!,
-        }]);
+        }));
     }
 
-    public containerLoadBalancers(): pulumi.Input<pulumi.Input<x.ecs.ContainerLoadBalancer>[]> {
-        return this.dependencies().apply(_ => [{
+    public containerLoadBalancer(): pulumi.Input<x.ecs.ContainerLoadBalancer> {
+        return this.dependencies().apply(_ => ({
             containerPort: this.targetGroup.port.apply(p => p!),
             targetGroupArn: this.targetGroup.arn,
-        }]);
+        }));
     }
 
     public listenerDefaultAction(): aws.elasticloadbalancingv2.ListenerArgs["defaultAction"] {


### PR DESCRIPTION
This improves the consumption side of things for users by making the shapes of our APIs feel more natural.  For example, instead of saying:

```ts
containers: {
    nginx: {
        portMappings: myTargetGroup;
    }
}
```

You instead say:

```ts
...
    portMappings: [myTargetGroup]
...
```

i.e. instead of passing a singular 'target group' that then goes into the plural 'portMappings', you pass the singular group as an element of an array.  This makes the singular/plural shapes make more sense.

this also provides the user with more flexibility as they can place multiple elements in the array.  For example, tehy can place a raw port-mapping object in the array, or they can place a callback (like a target-group) in the array.  The array can be heterogeneous as well.  Raw-objects and callbacks can be in the same array.